### PR TITLE
A couple fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@targomo/core",
   "description": "The JavaScript (& TypeScript) API for Targomo's time-based access mapping services.",
   "author": "Targomo",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "license": "MIT",
   "repository": "github:targomo/targomo-js",
   "homepage": "https://targomo.com/developers",

--- a/src/api/basemaps.ts
+++ b/src/api/basemaps.ts
@@ -60,6 +60,10 @@ export class BasemapsClient {
         if (!basemapName || !this.basemapsLookup[basemapName]) {
             throw new Error('valid style name required to access Targomo basemap');
         }
-        return UrlUtil.buildTargomoUrl(this.client.config.basemapsUrl, this.basemapsLookup[basemapName] + '.json', this.client.serviceKey);
+        return new UrlUtil.TargomoUrl(this.client)
+            .part(this.client.config.basemapsUrl)
+            .part(this.basemapsLookup[basemapName] + '.json')
+            .params({key: this.client.serviceKey})
+            .toString();
     }
 }

--- a/src/api/basemaps.ts
+++ b/src/api/basemaps.ts
@@ -59,6 +59,6 @@ export class BasemapsClient {
         if (!basemapName || !this.basemapsLookup[basemapName]) {
             throw new Error('valid style name required to access Targomo basemap');
         }
-        return 'https://maps.targomo.com/styles/' + this.basemapsLookup[basemapName] + '.json?key=' + this.client.serviceKey
+        return this.client.config.basemapsUrl + this.basemapsLookup[basemapName] + '.json?key=' + this.client.serviceKey
     }
 }

--- a/src/api/basemaps.ts
+++ b/src/api/basemaps.ts
@@ -1,4 +1,5 @@
 import { TargomoClient } from './targomoClient'
+import { UrlUtil } from '../util';
 /**
  * @Topic Basemaps
  * @General This is the entry point for using the basemaps provided by Targomo.
@@ -59,6 +60,6 @@ export class BasemapsClient {
         if (!basemapName || !this.basemapsLookup[basemapName]) {
             throw new Error('valid style name required to access Targomo basemap');
         }
-        return this.client.config.basemapsUrl + this.basemapsLookup[basemapName] + '.json?key=' + this.client.serviceKey
+        return UrlUtil.buildTargomoUrl(this.client.config.basemapsUrl, this.basemapsLookup[basemapName] + '.json', this.client.serviceKey);
     }
 }

--- a/src/api/basemaps.ts
+++ b/src/api/basemaps.ts
@@ -61,7 +61,7 @@ export class BasemapsClient {
             throw new Error('valid style name required to access Targomo basemap');
         }
         return new UrlUtil.TargomoUrl(this.client)
-            .part(this.client.config.basemapsUrl)
+            .host(this.client.config.basemapsUrl)
             .part(this.basemapsLookup[basemapName] + '.json')
             .params({key: this.client.serviceKey})
             .toString();

--- a/src/api/benchmarks.ts
+++ b/src/api/benchmarks.ts
@@ -32,12 +32,13 @@ export class BenchmarksClient {
       }))
     }
 
-    const url = UrlUtil.buildTargomoUrl(this.client.config.tilesUrl,
-      'benchmarks/scores_cumulative/' +
-      (this.client.config.version !== null && this.client.config.version !== undefined ? 'v' + this.client.config.version + '/' : '') +
-      encodeURIComponent('' + group),
-      this.client.serviceKey
-    );
+    const url = new UrlUtil.TargomoUrl(this.client)
+      .part(this.client.config.tilesUrl)
+      .part('benchmarks/scores_cumulative')
+      .version()
+      .part(encodeURIComponent('' + group))
+      .key()
+      .toString();
 
     return await requests(this.client).fetch(url, 'POST', data)
   }
@@ -47,12 +48,14 @@ export class BenchmarksClient {
    */
   async metadata(key: StatisticsGroupId): Promise<any[]> {
 
-    const url = UrlUtil.buildTargomoUrl(this.client.config.tilesUrl,
-      '/benchmarks/meta/' +
-      (this.client.config.version !== null && this.client.config.version !== undefined ? 'v' + this.client.config.version + '/' : '') +
-      encodeURIComponent('' + key),
-      this.client.serviceKey
-    );
+    const url = new UrlUtil.TargomoUrl(this.client)
+      .part(this.client.config.tilesUrl)
+      .part('benchmarks/meta')
+      .version()
+      .part(encodeURIComponent('' + key))
+      .key()
+      .toString();
+
     return await requests(this.client).fetch(url)
   }
 }

--- a/src/api/benchmarks.ts
+++ b/src/api/benchmarks.ts
@@ -13,7 +13,7 @@ export class BenchmarksClient {
   /**
    *
    */
-  async fetch(group: StatisticsGroupId, conditions: BenchmarkCriteria[], bounds: BoundingBox, version: number = 1): Promise<any> {
+  async fetch(group: StatisticsGroupId, conditions: BenchmarkCriteria[], bounds: BoundingBox): Promise<any> {
     // TODO: have a "Payload" object
     const boundsData = {
       'west': bounds.southWest.lng,
@@ -32,7 +32,8 @@ export class BenchmarksClient {
       }))
     }
 
-    const url = `${this.client.config.tilesUrl}/benchmarks/scores_cumulative/v${version}/${encodeURIComponent('' + group)}`
+    const url = `${this.client.config.tilesUrl}/benchmarks/scores_cumulative/v` +
+    `${this.client.config.version}/${encodeURIComponent('' + group)}`
      + `?key=${encodeURIComponent(this.client.serviceKey)}`
     return await requests(this.client).fetch(url, 'POST', data)
   }
@@ -40,8 +41,8 @@ export class BenchmarksClient {
   /**
    *
    */
-  async metadata(key: StatisticsGroupId, version: number = 1): Promise<any[]> {
-    const url = `${this.client.config.tilesUrl}/benchmarks/meta/v${version}/${encodeURIComponent('' + key)}`
+  async metadata(key: StatisticsGroupId): Promise<any[]> {
+    const url = `${this.client.config.tilesUrl}/benchmarks/meta/v${this.client.config.version}/${encodeURIComponent('' + key)}`
                   + `?key=${encodeURIComponent(this.client.serviceKey)}`
     return await requests(this.client).fetch(url)
   }

--- a/src/api/benchmarks.ts
+++ b/src/api/benchmarks.ts
@@ -33,10 +33,10 @@ export class BenchmarksClient {
     }
 
     const url = new UrlUtil.TargomoUrl(this.client)
-      .part(this.client.config.tilesUrl)
-      .part('benchmarks/scores_cumulative')
+      .host(this.client.config.tilesUrl)
+      .part('benchmarks/scores_cumulative/')
       .version()
-      .part(encodeURIComponent('' + group))
+      .part('/' + encodeURIComponent('' + group))
       .key()
       .toString();
 
@@ -49,10 +49,10 @@ export class BenchmarksClient {
   async metadata(key: StatisticsGroupId): Promise<any[]> {
 
     const url = new UrlUtil.TargomoUrl(this.client)
-      .part(this.client.config.tilesUrl)
-      .part('benchmarks/meta')
+      .host(this.client.config.tilesUrl)
+      .part('benchmarks/meta/')
       .version()
-      .part(encodeURIComponent('' + key))
+      .part('/' + encodeURIComponent('' + key))
       .key()
       .toString();
 

--- a/src/api/benchmarks.ts
+++ b/src/api/benchmarks.ts
@@ -13,7 +13,7 @@ export class BenchmarksClient {
   /**
    *
    */
-  async fetch(group: StatisticsGroupId, conditions: BenchmarkCriteria[], bounds: BoundingBox): Promise<any> {
+  async fetch(group: StatisticsGroupId, conditions: BenchmarkCriteria[], bounds: BoundingBox, version: number = 1): Promise<any> {
     // TODO: have a "Payload" object
     const boundsData = {
       'west': bounds.southWest.lng,
@@ -32,16 +32,16 @@ export class BenchmarksClient {
       }))
     }
 
-    const url = `${this.client.config.tilesUrl}/benchmarks/scores_cumulative/v1/${encodeURIComponent('' + group)}`
-                 + `?key=${encodeURIComponent(this.client.serviceKey)}`
+    const url = `${this.client.config.tilesUrl}/benchmarks/scores_cumulative/v${version}/${encodeURIComponent('' + group)}`
+     + `?key=${encodeURIComponent(this.client.serviceKey)}`
     return await requests(this.client).fetch(url, 'POST', data)
   }
 
   /**
    *
    */
-  async metadata(key: StatisticsGroupId): Promise<any[]> {
-    const url = `${this.client.config.tilesUrl}/benchmarks/meta/v1/${encodeURIComponent('' + key)}`
+  async metadata(key: StatisticsGroupId, version: number = 1): Promise<any[]> {
+    const url = `${this.client.config.tilesUrl}/benchmarks/meta/v${version}/${encodeURIComponent('' + key)}`
                   + `?key=${encodeURIComponent(this.client.serviceKey)}`
     return await requests(this.client).fetch(url)
   }

--- a/src/api/benchmarks.ts
+++ b/src/api/benchmarks.ts
@@ -1,5 +1,5 @@
 import { TargomoClient } from './targomoClient'
-import { StatisticsGroupId, BenchmarkCriteria, BoundingBox } from '../index';
+import { StatisticsGroupId, BenchmarkCriteria, BoundingBox, UrlUtil } from '../index';
 import { requests} from '../util/requestUtil';
 
 /**
@@ -32,9 +32,13 @@ export class BenchmarksClient {
       }))
     }
 
-    const url = `${this.client.config.tilesUrl}/benchmarks/scores_cumulative/v` +
-    `${this.client.config.version}/${encodeURIComponent('' + group)}`
-     + `?key=${encodeURIComponent(this.client.serviceKey)}`
+    const url = UrlUtil.buildTargomoUrl(this.client.config.tilesUrl,
+      'benchmarks/scores_cumulative/' +
+      (this.client.config.version !== null && this.client.config.version !== undefined ? 'v' + this.client.config.version + '/' : '') +
+      encodeURIComponent('' + group),
+      this.client.serviceKey
+    );
+
     return await requests(this.client).fetch(url, 'POST', data)
   }
 
@@ -42,8 +46,13 @@ export class BenchmarksClient {
    *
    */
   async metadata(key: StatisticsGroupId): Promise<any[]> {
-    const url = `${this.client.config.tilesUrl}/benchmarks/meta/v${this.client.config.version}/${encodeURIComponent('' + key)}`
-                  + `?key=${encodeURIComponent(this.client.serviceKey)}`
+
+    const url = UrlUtil.buildTargomoUrl(this.client.config.tilesUrl,
+      '/benchmarks/meta/' +
+      (this.client.config.version !== null && this.client.config.version !== undefined ? 'v' + this.client.config.version + '/' : '') +
+      encodeURIComponent('' + key),
+      this.client.serviceKey
+    );
     return await requests(this.client).fetch(url)
   }
 }

--- a/src/api/clientConfig.ts
+++ b/src/api/clientConfig.ts
@@ -12,7 +12,7 @@ export interface ClientOptions {
   overpassUrl?: string
   fleetsUrl?: string
   requestTimeout?: number
-
+  version?: number
   routeTypes?: {routeType: string | number, color: string, haloColor: string}[]
 }
 
@@ -28,7 +28,7 @@ export class ClientConfig implements ClientOptions {
   fleetsUrl: string = 'https://api.targomo.com/fleetplanner/v1/'
   basemapsUrl: string = 'https://maps.targomo.com/styles/'
   requestTimeout: 20000
-
+  version: number = 1
 
   // routeTypes  = [
   //   // non transit

--- a/src/api/clientConfig.ts
+++ b/src/api/clientConfig.ts
@@ -18,13 +18,13 @@ export interface ClientOptions {
 
 export class ClientConfig implements ClientOptions {
 
-  serverUrl: string = 'https://api.targomo.com'
-  statisticsUrl: string = 'https://api.targomo.com/statistics'
-  tilesUrl: string = 'https://api.targomo.com/vector-statistics'
-  poiUrl: string = 'https://api.targomo.com/pointofinterest'
-  mapTilesUrl: string = 'https://maps.targomo.com'
-  photonGeocoderUrl: string = 'https://api.targomo.com/geocode'
-  overpassUrl: string = 'https://api.targomo.com/overpass'
+  serverUrl: string = 'https://api.targomo.com/'
+  statisticsUrl: string = 'https://api.targomo.com/statistics/'
+  tilesUrl: string = 'https://api.targomo.com/vector-statistics/'
+  poiUrl: string = 'https://api.targomo.com/pointofinterest/'
+  mapTilesUrl: string = 'https://maps.targomo.com/'
+  photonGeocoderUrl: string = 'https://api.targomo.com/geocode/'
+  overpassUrl: string = 'https://api.targomo.com/overpass/'
   fleetsUrl: string = 'https://api.targomo.com/fleetplanner/'
   basemapsUrl: string = 'https://maps.targomo.com/styles/'
   requestTimeout: 20000

--- a/src/api/clientConfig.ts
+++ b/src/api/clientConfig.ts
@@ -25,7 +25,7 @@ export class ClientConfig implements ClientOptions {
   mapTilesUrl: string = 'https://maps.targomo.com'
   photonGeocoderUrl: string = 'https://api.targomo.com/geocode'
   overpassUrl: string = 'https://api.targomo.com/overpass'
-  fleetsUrl: string = 'https://api.targomo.com/fleetplanner/v1/'
+  fleetsUrl: string = 'https://api.targomo.com/fleetplanner/'
   basemapsUrl: string = 'https://maps.targomo.com/styles/'
   requestTimeout: 20000
   version: number = 1

--- a/src/api/clientConfig.ts
+++ b/src/api/clientConfig.ts
@@ -25,8 +25,8 @@ export class ClientConfig implements ClientOptions {
   mapTilesUrl: string = 'https://maps.targomo.com'
   photonGeocoderUrl: string = 'https://api.targomo.com/geocode'
   overpassUrl: string = 'https://api.targomo.com/overpass'
-  fleetsUrl: string = 'https://api.targomo.com/fleetplanner'
-
+  fleetsUrl: string = 'https://api.targomo.com/fleetplanner/v1/'
+  basemapsUrl: string = 'https://maps.targomo.com/styles/'
   requestTimeout: 20000
 
 

--- a/src/api/fleets.ts
+++ b/src/api/fleets.ts
@@ -69,7 +69,12 @@ export class FleetsClient {
    */
   async fetch(stores: FpStore[], orders: FpOrder[], transports: FpTransport[], options: FpRequestOptions): Promise<FpResult> {
 
-    const url = UrlUtil.buildTargomoUrl(this.client.config.fleetsUrl, 'api/key-auth/optimizations', this.client.serviceKey)
+    const url = UrlUtil.buildTargomoUrl(
+      this.client.config.fleetsUrl,
+      (this.client.config.version !== null && this.client.config.version !== undefined ? 'v' + this.client.config.version + '/' : '') +
+      'api/key-auth/optimizations',
+      this.client.serviceKey
+    )
     const cfg = this._createPayload(this.client, stores, orders, transports, options);
 
     const result = await requests(this.client, options).fetch(url, 'POST', cfg);

--- a/src/api/fleets.ts
+++ b/src/api/fleets.ts
@@ -70,9 +70,9 @@ export class FleetsClient {
   async fetch(stores: FpStore[], orders: FpOrder[], transports: FpTransport[], options: FpRequestOptions): Promise<FpResult> {
 
     const url = new UrlUtil.TargomoUrl(this.client)
-      .part(this.client.config.fleetsUrl)
+      .host(this.client.config.fleetsUrl)
       .version()
-      .part('api/key-auth/optimizations')
+      .part('/api/key-auth/optimizations')
       .key()
       .toString();
 

--- a/src/api/fleets.ts
+++ b/src/api/fleets.ts
@@ -69,8 +69,7 @@ export class FleetsClient {
    */
   async fetch(stores: FpStore[], orders: FpOrder[], transports: FpTransport[], options: FpRequestOptions): Promise<FpResult> {
 
-    const url =
-      UrlUtil.buildTargomoUrl(this.client.config.fleetsUrl, 'api/key-auth/optimizations', this.client.serviceKey, true)
+    const url = UrlUtil.buildTargomoUrl(this.client.config.fleetsUrl, 'api/key-auth/optimizations', this.client.serviceKey)
     const cfg = this._createPayload(this.client, stores, orders, transports, options);
 
     const result = await requests(this.client, options).fetch(url, 'POST', cfg);

--- a/src/api/fleets.ts
+++ b/src/api/fleets.ts
@@ -108,7 +108,7 @@ export class FleetsClient {
           fallbackServiceUrl: '',
           edgeWeight: options.edgeWeight,
           maxEdgeWeight: options.maxEdgeWeight,
-          elevationEnabled: options.elevation,
+          elevation: options.elevation,
           rushHour: options.rushHour
         }
       },

--- a/src/api/fleets.ts
+++ b/src/api/fleets.ts
@@ -69,12 +69,13 @@ export class FleetsClient {
    */
   async fetch(stores: FpStore[], orders: FpOrder[], transports: FpTransport[], options: FpRequestOptions): Promise<FpResult> {
 
-    const url = UrlUtil.buildTargomoUrl(
-      this.client.config.fleetsUrl,
-      (this.client.config.version !== null && this.client.config.version !== undefined ? 'v' + this.client.config.version + '/' : '') +
-      'api/key-auth/optimizations',
-      this.client.serviceKey
-    )
+    const url = new UrlUtil.TargomoUrl(this.client)
+      .part(this.client.config.fleetsUrl)
+      .version()
+      .part('api/key-auth/optimizations')
+      .key()
+      .toString();
+
     const cfg = this._createPayload(this.client, stores, orders, transports, options);
 
     const result = await requests(this.client, options).fetch(url, 'POST', cfg);

--- a/src/api/geocode.ts
+++ b/src/api/geocode.ts
@@ -36,7 +36,10 @@ export class GeocodeEsriClient {
       params.magicKey = magicKey
     }
 
-    const url = 'https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/findAddressCandidates?' + UrlUtil.queryToString(params)
+    const url = new UrlUtil.TargomoUrl()
+      .part('https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/findAddressCandidates')
+      .params(params)
+      .toString();
     const jsonResult = await requests().fetch(url)
 
     const results = jsonResult.candidates.map(function (result: any) {
@@ -75,9 +78,11 @@ export class GeocodeEsriClient {
     if (center) {
       params.location = `${center.lng},${center.lat}`
     }
-
-    const response = await requests().fetch('https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/suggest?'
-                                                        + UrlUtil.queryToString(params))
+    const url = new UrlUtil.TargomoUrl()
+      .part('https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/suggest')
+      .params(params)
+      .toString();
+    const response = await requests().fetch(url)
 
     return response.suggestions
   }
@@ -97,8 +102,12 @@ export class GeocodeEsriClient {
 
     params.location = `${location.lng},${location.lat}`
 
-    const response = await requests().fetch('https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/reverseGeocode?'
-                                                       + UrlUtil.queryToString(params))
+    const url = new UrlUtil.TargomoUrl()
+      .part('https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/reverseGeocode')
+      .params(params)
+      .toString();
+
+    const response = await requests().fetch(url)
     if (response && response.address) {
       const result = {
         address: response.address.Match_addr,

--- a/src/api/geocodePhoton.ts
+++ b/src/api/geocodePhoton.ts
@@ -1,5 +1,5 @@
 import { TargomoClient } from './targomoClient'
-import { GeoSearchDescription, LatLng } from '../index';
+import { GeoSearchDescription, LatLng, UrlUtil } from '../index';
 import { requests} from '../util/requestUtil';
 
 export class GeocodePhotonClient {
@@ -7,9 +7,16 @@ export class GeocodePhotonClient {
   }
 
   async geocode(query: string, center?: LatLng, language?: string): Promise<any[]> {
-    const geocoderUrl = this.client.config.photonGeocoderUrl
-    // let url = geocoderUrl + '/geocode/api/?q=' + encodeURIComponent(query) + '&limit=5'
-    let url = geocoderUrl + '/api/?q=' + encodeURIComponent(query) + '&limit=5'
+
+
+    let url = new UrlUtil.TargomoUrl()
+      .part(this.client.config.photonGeocoderUrl)
+      .part('api')
+      .params({
+        q: encodeURIComponent(query),
+        limit: 5
+      })
+      .toString();
 
     if (center) {
       url += '&lat=' + center.lat + '&lon=' + center.lng

--- a/src/api/geocodePhoton.ts
+++ b/src/api/geocodePhoton.ts
@@ -10,7 +10,7 @@ export class GeocodePhotonClient {
 
 
     let url = new UrlUtil.TargomoUrl()
-      .part(this.client.config.photonGeocoderUrl)
+      .host(this.client.config.photonGeocoderUrl)
       .part('api')
       .params({
         q: encodeURIComponent(query),

--- a/src/api/multigraph.ts
+++ b/src/api/multigraph.ts
@@ -18,7 +18,7 @@ export class MultigraphClient {
     let url = new UrlUtil.TargomoUrl(this.client)
       .part(this.client.serviceUrl)
       .version()
-      .part('multigraph')
+      .part('/multigraph')
       .key()
       .toString();
 
@@ -32,7 +32,7 @@ export class MultigraphClient {
     let url = new UrlUtil.TargomoUrl(this.client)
       .part(this.client.serviceUrl)
       .version()
-      .part('multigraph/overview')
+      .part('/multigraph/overview')
       .key()
       .toString();
 
@@ -50,7 +50,7 @@ export class MultigraphClient {
     let url = new UrlUtil.TargomoUrl(this.client)
       .part(this.client.serviceUrl)
       .version()
-      .part('objectcache/add')
+      .part('/objectcache/add')
       .key()
       .toString();
 
@@ -60,7 +60,7 @@ export class MultigraphClient {
     return new UrlUtil.TargomoUrl(this.client)
       .part(this.client.serviceUrl)
       .version()
-      .part('multigraph/{z}/{x}/{y}.' + format)
+      .part('/multigraph/{z}/{x}/{y}.' + format)
       .key()
       .params({
         cfgUuid: objectCache.uuid

--- a/src/api/multigraph.ts
+++ b/src/api/multigraph.ts
@@ -14,24 +14,28 @@ export class MultigraphClient {
 
    */
   async fetch(sources: LatLngIdTravelMode[], options: MultigraphRequestOptions, targets?: LatLngId[]): Promise<MgResult> {
-    const url = UrlUtil.buildTargomoUrl(
-      this.client.serviceUrl,
-      (this.client.config.version !== null && this.client.config.version !== undefined ? 'v' + this.client.config.version + '/' : '') +
-      'multigraph',
-      this.client.serviceKey
-    )
+
+    let url = new UrlUtil.TargomoUrl(this.client)
+      .part(this.client.serviceUrl)
+      .version()
+      .part('multigraph')
+      .key()
+      .toString();
+
     const cfg = new MultigraphRequestPayload(sources, options, targets);
     const result = await requests(this.client, options).fetch(url, 'POST', cfg);
     return result;
   }
 
   async fetchOverview(sources: LatLngIdTravelMode[], options: MultigraphRequestOptions, targets?: LatLngId[]): Promise<MgOverviewResult> {
-    const url = UrlUtil.buildTargomoUrl(
-      this.client.serviceUrl,
-      (this.client.config.version !== null && this.client.config.version !== undefined ? 'v' + this.client.config.version + '/' : '') +
-      'multigraph/overview',
-      this.client.serviceKey
-    )
+
+    let url = new UrlUtil.TargomoUrl(this.client)
+      .part(this.client.serviceUrl)
+      .version()
+      .part('multigraph/overview')
+      .key()
+      .toString();
+
     const cfg = new MultigraphRequestPayload(sources, options, targets);
     const result = await requests(this.client, options).fetch(url, 'POST', cfg);
     return result;
@@ -42,20 +46,25 @@ export class MultigraphClient {
     options: MultigraphRequestOptions,
     format: 'geojson' | 'json' | 'mvt',
     targets?: LatLngId[]): Promise<string> {
-    const url = UrlUtil.buildTargomoUrl(
-      this.client.serviceUrl,
-      (this.client.config.version !== null && this.client.config.version !== undefined ? 'v' + this.client.config.version + '/' : '') +
-      'objectcache/add',
-      this.client.serviceKey
-    )
+
+    let url = new UrlUtil.TargomoUrl(this.client)
+      .part(this.client.serviceUrl)
+      .version()
+      .part('objectcache/add')
+      .key()
+      .toString();
+
     const cfg = new MultigraphRequestPayload(sources, options, targets);
       // TODO ObjectCache should have its own client
     const objectCache: any = await requests(this.client, options).fetch(url, 'POST', cfg);
-    return UrlUtil.buildTargomoUrl(
-      this.client.serviceUrl,
-      (this.client.config.version !== null && this.client.config.version !== undefined ? 'v' + this.client.config.version + '/' : '') +
-      'multigraph/{z}/{x}/{y}.' + format,
-      this.client.serviceKey
-    ) + '&cfgUuid=' + objectCache.uuid;
+    return new UrlUtil.TargomoUrl(this.client)
+      .part(this.client.serviceUrl)
+      .version()
+      .part('multigraph/{z}/{x}/{y}.' + format)
+      .key()
+      .params({
+        cfgUuid: objectCache.uuid
+      })
+      .toString();
   }
 }

--- a/src/api/multigraph.ts
+++ b/src/api/multigraph.ts
@@ -14,7 +14,12 @@ export class MultigraphClient {
 
    */
   async fetch(sources: LatLngIdTravelMode[], options: MultigraphRequestOptions, targets?: LatLngId[]): Promise<MgResult> {
-    const url = UrlUtil.buildTargomoUrl(this.client.serviceUrl, 'v' + this.client.config.version + '/multigraph', this.client.serviceKey)
+    const url = UrlUtil.buildTargomoUrl(
+      this.client.serviceUrl,
+      (this.client.config.version !== null && this.client.config.version !== undefined ? 'v' + this.client.config.version + '/' : '') +
+      'multigraph',
+      this.client.serviceKey
+    )
     const cfg = new MultigraphRequestPayload(sources, options, targets);
     const result = await requests(this.client, options).fetch(url, 'POST', cfg);
     return result;
@@ -23,7 +28,8 @@ export class MultigraphClient {
   async fetchOverview(sources: LatLngIdTravelMode[], options: MultigraphRequestOptions, targets?: LatLngId[]): Promise<MgOverviewResult> {
     const url = UrlUtil.buildTargomoUrl(
       this.client.serviceUrl,
-      'v' + this.client.config.version + '/multigraph/overview',
+      (this.client.config.version !== null && this.client.config.version !== undefined ? 'v' + this.client.config.version + '/' : '') +
+      'multigraph/overview',
       this.client.serviceKey
     )
     const cfg = new MultigraphRequestPayload(sources, options, targets);
@@ -38,7 +44,8 @@ export class MultigraphClient {
     targets?: LatLngId[]): Promise<string> {
     const url = UrlUtil.buildTargomoUrl(
       this.client.serviceUrl,
-      'v' + this.client.config.version + '/objectcache/add',
+      (this.client.config.version !== null && this.client.config.version !== undefined ? 'v' + this.client.config.version + '/' : '') +
+      'objectcache/add',
       this.client.serviceKey
     )
     const cfg = new MultigraphRequestPayload(sources, options, targets);
@@ -46,7 +53,8 @@ export class MultigraphClient {
     const objectCache: any = await requests(this.client, options).fetch(url, 'POST', cfg);
     return UrlUtil.buildTargomoUrl(
       this.client.serviceUrl,
-      'v' + this.client.config.version + '/multigraph/{z}/{x}/{y}.' + format,
+      (this.client.config.version !== null && this.client.config.version !== undefined ? 'v' + this.client.config.version + '/' : '') +
+      'multigraph/{z}/{x}/{y}.' + format,
       this.client.serviceKey
     ) + '&cfgUuid=' + objectCache.uuid;
   }

--- a/src/api/multigraph.ts
+++ b/src/api/multigraph.ts
@@ -14,14 +14,18 @@ export class MultigraphClient {
 
    */
   async fetch(sources: LatLngIdTravelMode[], options: MultigraphRequestOptions, targets?: LatLngId[]): Promise<MgResult> {
-    const url = UrlUtil.buildTargomoUrl(this.client.serviceUrl, 'multigraph', this.client.serviceKey)
+    const url = UrlUtil.buildTargomoUrl(this.client.serviceUrl, 'v' + this.client.config.version + '/multigraph', this.client.serviceKey)
     const cfg = new MultigraphRequestPayload(sources, options, targets);
     const result = await requests(this.client, options).fetch(url, 'POST', cfg);
     return result;
   }
 
   async fetchOverview(sources: LatLngIdTravelMode[], options: MultigraphRequestOptions, targets?: LatLngId[]): Promise<MgOverviewResult> {
-    const url = UrlUtil.buildTargomoUrl(this.client.serviceUrl, 'multigraph/overview', this.client.serviceKey)
+    const url = UrlUtil.buildTargomoUrl(
+      this.client.serviceUrl,
+      'v' + this.client.config.version + '/multigraph/overview',
+      this.client.serviceKey
+    )
     const cfg = new MultigraphRequestPayload(sources, options, targets);
     const result = await requests(this.client, options).fetch(url, 'POST', cfg);
     return result;
@@ -32,13 +36,17 @@ export class MultigraphClient {
     options: MultigraphRequestOptions,
     format: 'geojson' | 'json' | 'mvt',
     targets?: LatLngId[]): Promise<string> {
-    const url = UrlUtil.buildTargomoUrl(this.client.serviceUrl, 'objectcache/add', this.client.serviceKey)
+    const url = UrlUtil.buildTargomoUrl(
+      this.client.serviceUrl,
+      'v' + this.client.config.version + '/objectcache/add',
+      this.client.serviceKey
+    )
     const cfg = new MultigraphRequestPayload(sources, options, targets);
       // TODO ObjectCache should have its own client
     const objectCache: any = await requests(this.client, options).fetch(url, 'POST', cfg);
     return UrlUtil.buildTargomoUrl(
       this.client.serviceUrl,
-      '/multigraph/{z}/{x}/{y}.' + format,
+      'v' + this.client.config.version + '/multigraph/{z}/{x}/{y}.' + format,
       this.client.serviceKey
     ) + '&cfgUuid=' + objectCache.uuid;
   }

--- a/src/api/multigraph.ts
+++ b/src/api/multigraph.ts
@@ -14,14 +14,14 @@ export class MultigraphClient {
 
    */
   async fetch(sources: LatLngIdTravelMode[], options: MultigraphRequestOptions, targets?: LatLngId[]): Promise<MgResult> {
-    const url = UrlUtil.buildTargomoUrl(this.client.serviceUrl, 'multigraph', this.client.serviceKey, true)
+    const url = UrlUtil.buildTargomoUrl(this.client.serviceUrl, 'multigraph', this.client.serviceKey)
     const cfg = new MultigraphRequestPayload(sources, options, targets);
     const result = await requests(this.client, options).fetch(url, 'POST', cfg);
     return result;
   }
 
   async fetchOverview(sources: LatLngIdTravelMode[], options: MultigraphRequestOptions, targets?: LatLngId[]): Promise<MgOverviewResult> {
-    const url = UrlUtil.buildTargomoUrl(this.client.serviceUrl, 'multigraph/overview', this.client.serviceKey, true)
+    const url = UrlUtil.buildTargomoUrl(this.client.serviceUrl, 'multigraph/overview', this.client.serviceKey)
     const cfg = new MultigraphRequestPayload(sources, options, targets);
     const result = await requests(this.client, options).fetch(url, 'POST', cfg);
     return result;
@@ -32,15 +32,14 @@ export class MultigraphClient {
     options: MultigraphRequestOptions,
     format: 'geojson' | 'json' | 'mvt',
     targets?: LatLngId[]): Promise<string> {
-    const url = UrlUtil.buildTargomoUrl(this.client.serviceUrl, 'objectcache/add', this.client.serviceKey, true)
+    const url = UrlUtil.buildTargomoUrl(this.client.serviceUrl, 'objectcache/add', this.client.serviceKey)
     const cfg = new MultigraphRequestPayload(sources, options, targets);
       // TODO ObjectCache should have its own client
     const objectCache: any = await requests(this.client, options).fetch(url, 'POST', cfg);
-    return this.client.serviceUrl +
-          'v1/multigraph/{z}/{x}/{y}.' +
-          format + '?key=' +
-          this.client.serviceKey +
-          '&cfgUuid=' +
-          objectCache.uuid;
+    return UrlUtil.buildTargomoUrl(
+      this.client.serviceUrl,
+      '/multigraph/{z}/{x}/{y}.' + format,
+      this.client.serviceKey
+    ) + '&cfgUuid=' + objectCache.uuid;
   }
 }

--- a/src/api/optimizations.ts
+++ b/src/api/optimizations.ts
@@ -26,11 +26,16 @@ export class OptimizationsClient {
       return null
     }
 
-    const url = UrlUtil.buildTargomoUrl(
-      this.client.config.statisticsUrl,
-      'simulation/start',
-      this.client.serviceKey
-    ) + '&serviceUrl=' + encodeURIComponent(this.client.serviceUrl)
+
+    const url = new UrlUtil.TargomoUrl(this.client)
+      .part(this.client.config.statisticsUrl)
+      .part('simulation/start')
+      .key()
+      .params({
+        serviceUrl: encodeURIComponent(this.client.serviceUrl)
+      })
+      .toString();
+
     const cfg = new OptimizationRequestPayload(this.client.serviceUrl, this.client.serviceKey, sources, options)
 
     const result = await requests(this.client, options).fetch(url, 'POST', cfg)
@@ -47,12 +52,14 @@ export class OptimizationsClient {
       optimizationId = [optimizationId]
     }
 
-    const url = UrlUtil.buildTargomoUrl(
-      this.client.config.statisticsUrl,
-      'simulation/ready',
-      this.client.serviceKey) +
-      '&serviceUrl=' + encodeURIComponent(this.client.serviceUrl) +
-      optimizationId.map(id => `&simulationId=${encodeURIComponent('' + +id)}`).join('')
+    const url = new UrlUtil.TargomoUrl(this.client)
+      .part(this.client.config.statisticsUrl)
+      .part('simulation/ready')
+      .key()
+      .params({
+        serviceUrl: encodeURIComponent(this.client.serviceUrl)
+      })
+      .toString() + optimizationId.map(id => `&simulationId=${encodeURIComponent('' + +id)}`).join('');
 
     return requests(this.client).fetch(url)
   }
@@ -63,10 +70,15 @@ export class OptimizationsClient {
    * @param optimizationId
    */
   async fetch(optimizationId: number) {
-    const url = UrlUtil.buildTargomoUrl(
-      this.client.config.statisticsUrl,
-      `simulation/${optimizationId}`, this.client.serviceKey
-      ) + '&serviceUrl=' + encodeURIComponent(this.client.serviceUrl)
+
+    const url = new UrlUtil.TargomoUrl(this.client)
+      .part(this.client.config.statisticsUrl)
+      .part('simulation/' + optimizationId)
+      .key()
+      .params({
+        serviceUrl: encodeURIComponent(this.client.serviceUrl)
+      })
+      .toString();
 
     return new OptimizationResult(await requests(this.client).fetch(url))
   }

--- a/src/api/optimizations.ts
+++ b/src/api/optimizations.ts
@@ -57,9 +57,10 @@ export class OptimizationsClient {
       .part('simulation/ready/')
       .key()
       .params({
-        serviceUrl: encodeURIComponent(this.client.serviceUrl)
+        serviceUrl: encodeURIComponent(this.client.serviceUrl),
+        simulationId: optimizationId
       })
-      .toString() + optimizationId.map(id => `&simulationId=${encodeURIComponent('' + +id)}`).join('');
+      .toString();
 
     return requests(this.client).fetch(url)
   }

--- a/src/api/optimizations.ts
+++ b/src/api/optimizations.ts
@@ -28,8 +28,8 @@ export class OptimizationsClient {
 
 
     const url = new UrlUtil.TargomoUrl(this.client)
-      .part(this.client.config.statisticsUrl)
-      .part('simulation/start')
+      .host(this.client.config.statisticsUrl)
+      .part('simulation/start/')
       .key()
       .params({
         serviceUrl: encodeURIComponent(this.client.serviceUrl)
@@ -53,8 +53,8 @@ export class OptimizationsClient {
     }
 
     const url = new UrlUtil.TargomoUrl(this.client)
-      .part(this.client.config.statisticsUrl)
-      .part('simulation/ready')
+      .host(this.client.config.statisticsUrl)
+      .part('simulation/ready/')
       .key()
       .params({
         serviceUrl: encodeURIComponent(this.client.serviceUrl)
@@ -72,8 +72,8 @@ export class OptimizationsClient {
   async fetch(optimizationId: number) {
 
     const url = new UrlUtil.TargomoUrl(this.client)
-      .part(this.client.config.statisticsUrl)
-      .part('simulation/' + optimizationId)
+      .host(this.client.config.statisticsUrl)
+      .part('simulation/' + optimizationId + '/')
       .key()
       .params({
         serviceUrl: encodeURIComponent(this.client.serviceUrl)

--- a/src/api/optimizations.ts
+++ b/src/api/optimizations.ts
@@ -7,7 +7,7 @@ import { OptimizationRequestPayload } from './payload/optimizationRequestPayload
 import { OptimizationResult } from '../types/responses/optimizationResult';
 
 /**
- *  @Topic Optimizations
+ * @Topic Optimizations
  */
 export class OptimizationsClient {
   constructor(private client: TargomoClient) {

--- a/src/api/optimizations.ts
+++ b/src/api/optimizations.ts
@@ -26,8 +26,11 @@ export class OptimizationsClient {
       return null
     }
 
-    const url = UrlUtil.buildTargomoUrl(this.client.config.statisticsUrl, 'simulation/start', this.client.serviceKey)
-                + '&serviceUrl=' + encodeURIComponent(this.client.serviceUrl)
+    const url = UrlUtil.buildTargomoUrl(
+      this.client.config.statisticsUrl,
+      'simulation/start',
+      this.client.serviceKey
+    ) + '&serviceUrl=' + encodeURIComponent(this.client.serviceUrl)
     const cfg = new OptimizationRequestPayload(this.client.serviceUrl, this.client.serviceKey, sources, options)
 
     const result = await requests(this.client, options).fetch(url, 'POST', cfg)
@@ -44,9 +47,12 @@ export class OptimizationsClient {
       optimizationId = [optimizationId]
     }
 
-    const url = UrlUtil.buildTargomoUrl(this.client.config.statisticsUrl, 'simulation/ready', this.client.serviceKey)
-                + '&serviceUrl=' + encodeURIComponent(this.client.serviceUrl)
-                + optimizationId.map(id => `&simulationId=${encodeURIComponent('' + +id)}`).join('')
+    const url = UrlUtil.buildTargomoUrl(
+      this.client.config.statisticsUrl,
+      'simulation/ready',
+      this.client.serviceKey) +
+      '&serviceUrl=' + encodeURIComponent(this.client.serviceUrl) +
+      optimizationId.map(id => `&simulationId=${encodeURIComponent('' + +id)}`).join('')
 
     return requests(this.client).fetch(url)
   }
@@ -57,8 +63,10 @@ export class OptimizationsClient {
    * @param optimizationId
    */
   async fetch(optimizationId: number) {
-    const url = UrlUtil.buildTargomoUrl(this.client.config.statisticsUrl, `simulation/${optimizationId}`, this.client.serviceKey)
-                + '&serviceUrl=' + encodeURIComponent(this.client.serviceUrl)
+    const url = UrlUtil.buildTargomoUrl(
+      this.client.config.statisticsUrl,
+      `simulation/${optimizationId}`, this.client.serviceKey
+      ) + '&serviceUrl=' + encodeURIComponent(this.client.serviceUrl)
 
     return new OptimizationResult(await requests(this.client).fetch(url))
   }

--- a/src/api/optimizations.ts
+++ b/src/api/optimizations.ts
@@ -26,7 +26,7 @@ export class OptimizationsClient {
       return null
     }
 
-    const url = UrlUtil.buildTargomoUrl(this.client.config.statisticsUrl, 'simulation/start', this.client.serviceKey, false)
+    const url = UrlUtil.buildTargomoUrl(this.client.config.statisticsUrl, 'simulation/start', this.client.serviceKey)
                 + '&serviceUrl=' + encodeURIComponent(this.client.serviceUrl)
     const cfg = new OptimizationRequestPayload(this.client.serviceUrl, this.client.serviceKey, sources, options)
 
@@ -44,7 +44,7 @@ export class OptimizationsClient {
       optimizationId = [optimizationId]
     }
 
-    const url = UrlUtil.buildTargomoUrl(this.client.config.statisticsUrl, 'simulation/ready', this.client.serviceKey, false)
+    const url = UrlUtil.buildTargomoUrl(this.client.config.statisticsUrl, 'simulation/ready', this.client.serviceKey)
                 + '&serviceUrl=' + encodeURIComponent(this.client.serviceUrl)
                 + optimizationId.map(id => `&simulationId=${encodeURIComponent('' + +id)}`).join('')
 
@@ -57,7 +57,7 @@ export class OptimizationsClient {
    * @param optimizationId
    */
   async fetch(optimizationId: number) {
-    const url = UrlUtil.buildTargomoUrl(this.client.config.statisticsUrl, `simulation/${optimizationId}`, this.client.serviceKey, false)
+    const url = UrlUtil.buildTargomoUrl(this.client.config.statisticsUrl, `simulation/${optimizationId}`, this.client.serviceKey)
                 + '&serviceUrl=' + encodeURIComponent(this.client.serviceUrl)
 
     return new OptimizationResult(await requests(this.client).fetch(url))

--- a/src/api/payload/fleetsRequestPayload.ts
+++ b/src/api/payload/fleetsRequestPayload.ts
@@ -21,7 +21,7 @@ export interface FpRequestMetadata {
     fallbackServiceUrl: string,
     edgeWeight: EdgeWeightType,
     maxEdgeWeight: number,
-    elevationEnabled: boolean,
+    elevation: boolean,
     rushHour: boolean
   }
 }

--- a/src/api/payload/statefulMultigraphRequestPayload.ts
+++ b/src/api/payload/statefulMultigraphRequestPayload.ts
@@ -49,7 +49,7 @@ export class StatefulMultigraphRequestPayload extends StatisticsRequestPayload {
         this.multiGraphAggregationType = options.multigraph.aggregation.type || null
         this.multiGraphAggregationIgnoreOutlier = options.multigraph.aggregation.ignoreOutliers || null
         this.multiGraphAggregationMinSourcesRatio = options.multigraph.aggregation.minSourcesRatio || null
-        this.multiGraphAggregationMinSourcesCount = options.multigraph.aggregation.minSourceCount || null
+        this.multiGraphAggregationMinSourcesCount = options.multigraph.aggregation.minSourcesCount || null
         this.multiGraphAggregationMaxResultValueRatio = options.multigraph.aggregation.maxResultValueRatio || null
         this.multiGraphAggregationMaxResultValue = options.multigraph.aggregation.maxResultValue || null
       }

--- a/src/api/pointsOfInterest.ts
+++ b/src/api/pointsOfInterest.ts
@@ -54,7 +54,7 @@ function parseOSMLocation(item: any): OSMLatLng {
  */
 // TODO: better method names
 /**
- *  @Topic Points of Interest
+ * @Topic Points of Interest
  */
 export class PointsOfInterestClient {
   // Idea is this will be instantiated internally in Targomoclient,. and will receive instance of parent in its constructor

--- a/src/api/polygons.ts
+++ b/src/api/polygons.ts
@@ -41,7 +41,12 @@ export class PolygonsClient {
   }
 
   private async _executeFetch(sources: LatLngId[], options: PolygonRequestOptions, cfg: PolygonRequestPayload): Promise<{}> {
-    const url = UrlUtil.buildTargomoUrl(this.client.serviceUrl, 'v' + this.client.config.version + '/polygon', this.client.serviceKey)
+    const url = UrlUtil.buildTargomoUrl(
+      this.client.serviceUrl,
+      (this.client.config.version !== null && this.client.config.version !== undefined ? 'v' + this.client.config.version + '/' : '') +
+      'polygon',
+      this.client.serviceKey
+    )
     const result = await requests(this.client, options).fetchCachedData(options.useClientCache, url, 'POST', cfg);
     result.metadata = options
     return result

--- a/src/api/polygons.ts
+++ b/src/api/polygons.ts
@@ -45,7 +45,7 @@ export class PolygonsClient {
     const url = new UrlUtil.TargomoUrl(this.client)
       .part(this.client.serviceUrl)
       .version()
-      .part('polygon')
+      .part('/polygon')
       .key()
       .toString();
 

--- a/src/api/polygons.ts
+++ b/src/api/polygons.ts
@@ -41,12 +41,14 @@ export class PolygonsClient {
   }
 
   private async _executeFetch(sources: LatLngId[], options: PolygonRequestOptions, cfg: PolygonRequestPayload): Promise<{}> {
-    const url = UrlUtil.buildTargomoUrl(
-      this.client.serviceUrl,
-      (this.client.config.version !== null && this.client.config.version !== undefined ? 'v' + this.client.config.version + '/' : '') +
-      'polygon',
-      this.client.serviceKey
-    )
+
+    const url = new UrlUtil.TargomoUrl(this.client)
+      .part(this.client.serviceUrl)
+      .version()
+      .part('polygon')
+      .key()
+      .toString();
+
     const result = await requests(this.client, options).fetchCachedData(options.useClientCache, url, 'POST', cfg);
     result.metadata = options
     return result

--- a/src/api/polygons.ts
+++ b/src/api/polygons.ts
@@ -9,7 +9,7 @@ import { FeatureCollection, MultiPolygon } from 'geojson';
 
 
 /**
- *  @Topic Polygons
+ * @Topic Polygons
  */
 export class PolygonsClient {
   constructor(private client: TargomoClient) {

--- a/src/api/polygons.ts
+++ b/src/api/polygons.ts
@@ -41,7 +41,7 @@ export class PolygonsClient {
   }
 
   private async _executeFetch(sources: LatLngId[], options: PolygonRequestOptions, cfg: PolygonRequestPayload): Promise<{}> {
-    const url = UrlUtil.buildTargomoUrl(this.client.serviceUrl, 'polygon', this.client.serviceKey)
+    const url = UrlUtil.buildTargomoUrl(this.client.serviceUrl, 'v' + this.client.config.version + '/polygon', this.client.serviceKey)
     const result = await requests(this.client, options).fetchCachedData(options.useClientCache, url, 'POST', cfg);
     result.metadata = options
     return result

--- a/src/api/reachability.ts
+++ b/src/api/reachability.ts
@@ -20,12 +20,13 @@ export class ReachabilityClient {
    * @param options
    */
   async individual(sources: LatLngIdTravelMode[], targets: LatLngId[], options: TimeRequestOptions): Promise<TimeResult[]> {
-    const url = UrlUtil.buildTargomoUrl(
-      this.client.serviceUrl,
-      (this.client.config.version !== null && this.client.config.version !== undefined ? 'v' + this.client.config.version + '/' : '') +
-      'time',
-      this.client.serviceKey
-    )
+    const url = new UrlUtil.TargomoUrl(this.client)
+      .part(this.client.serviceUrl)
+      .version()
+      .part('time')
+      .key()
+      .toString();
+
     const cfg = new TimeRequestPayload(this.client, sources, targets, options)
     return await requests(this.client, options).fetchCachedData(options.useClientCache, url, 'POST', cfg)
   }
@@ -39,12 +40,13 @@ export class ReachabilityClient {
    * @param options
    */
   async combined(sources: LatLngId[], targets: LatLngId[], options: TimeRequestOptions): Promise<ReachabilityResult[]> {
-    const url = UrlUtil.buildTargomoUrl(
-      this.client.serviceUrl,
-      (this.client.config.version !== null && this.client.config.version !== undefined ? 'v' + this.client.config.version + '/' : '') +
-      'reachability',
-      this.client.serviceKey
-    )
+    const url = new UrlUtil.TargomoUrl(this.client)
+      .part(this.client.serviceUrl)
+      .version()
+      .part('reachability')
+      .key()
+      .toString();
+
     const cfg = new TimeRequestPayload(this.client, sources, targets, options)
     // TODO: add timeout
     return await requests(this.client, options).fetchCachedData(options.useClientCache, url, 'POST', cfg)

--- a/src/api/reachability.ts
+++ b/src/api/reachability.ts
@@ -20,7 +20,7 @@ export class ReachabilityClient {
    * @param options
    */
   async individual(sources: LatLngIdTravelMode[], targets: LatLngId[], options: TimeRequestOptions): Promise<TimeResult[]> {
-    const url = UrlUtil.buildTargomoUrl(this.client.serviceUrl, 'time', this.client.serviceKey)
+    const url = UrlUtil.buildTargomoUrl(this.client.serviceUrl, 'v' + this.client.config.version + '/time', this.client.serviceKey)
     const cfg = new TimeRequestPayload(this.client, sources, targets, options)
     return await requests(this.client, options).fetchCachedData(options.useClientCache, url, 'POST', cfg)
   }
@@ -34,7 +34,7 @@ export class ReachabilityClient {
    * @param options
    */
   async combined(sources: LatLngId[], targets: LatLngId[], options: TimeRequestOptions): Promise<ReachabilityResult[]> {
-    const url = UrlUtil.buildTargomoUrl(this.client.serviceUrl, 'reachability', this.client.serviceKey)
+    const url = UrlUtil.buildTargomoUrl(this.client.serviceUrl, 'v' + this.client.config.version + '/reachability', this.client.serviceKey)
     const cfg = new TimeRequestPayload(this.client, sources, targets, options)
     // TODO: add timeout
     return await requests(this.client, options).fetchCachedData(options.useClientCache, url, 'POST', cfg)

--- a/src/api/reachability.ts
+++ b/src/api/reachability.ts
@@ -20,7 +20,12 @@ export class ReachabilityClient {
    * @param options
    */
   async individual(sources: LatLngIdTravelMode[], targets: LatLngId[], options: TimeRequestOptions): Promise<TimeResult[]> {
-    const url = UrlUtil.buildTargomoUrl(this.client.serviceUrl, 'v' + this.client.config.version + '/time', this.client.serviceKey)
+    const url = UrlUtil.buildTargomoUrl(
+      this.client.serviceUrl,
+      (this.client.config.version !== null && this.client.config.version !== undefined ? 'v' + this.client.config.version + '/' : '') +
+      'time',
+      this.client.serviceKey
+    )
     const cfg = new TimeRequestPayload(this.client, sources, targets, options)
     return await requests(this.client, options).fetchCachedData(options.useClientCache, url, 'POST', cfg)
   }
@@ -34,7 +39,12 @@ export class ReachabilityClient {
    * @param options
    */
   async combined(sources: LatLngId[], targets: LatLngId[], options: TimeRequestOptions): Promise<ReachabilityResult[]> {
-    const url = UrlUtil.buildTargomoUrl(this.client.serviceUrl, 'v' + this.client.config.version + '/reachability', this.client.serviceKey)
+    const url = UrlUtil.buildTargomoUrl(
+      this.client.serviceUrl,
+      (this.client.config.version !== null && this.client.config.version !== undefined ? 'v' + this.client.config.version + '/' : '') +
+      'reachability',
+      this.client.serviceKey
+    )
     const cfg = new TimeRequestPayload(this.client, sources, targets, options)
     // TODO: add timeout
     return await requests(this.client, options).fetchCachedData(options.useClientCache, url, 'POST', cfg)

--- a/src/api/reachability.ts
+++ b/src/api/reachability.ts
@@ -23,7 +23,7 @@ export class ReachabilityClient {
     const url = new UrlUtil.TargomoUrl(this.client)
       .part(this.client.serviceUrl)
       .version()
-      .part('time')
+      .part('/time')
       .key()
       .toString();
 
@@ -43,7 +43,7 @@ export class ReachabilityClient {
     const url = new UrlUtil.TargomoUrl(this.client)
       .part(this.client.serviceUrl)
       .version()
-      .part('reachability')
+      .part('/reachability')
       .key()
       .toString();
 

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -21,7 +21,7 @@ export class RoutesClient {
    */
   async fetch(sources: LatLngIdTravelMode[], targets: LatLngId[], options: RouteRequestOptions): Promise<Route[]> {
     const cfg = new RouteRequestPayload(this.client, sources, targets, options)
-    const url = UrlUtil.buildTargomoUrl(this.client.serviceUrl, 'route',
+    const url = UrlUtil.buildTargomoUrl(this.client.serviceUrl, 'v' + this.client.config.version + '/route',
       this.client.serviceKey) + '&cfg=' + encodeURIComponent(JSON.stringify(cfg))
     const result = await requests(this.client, options).fetchCachedData(options.useClientCache, url, 'GET', undefined, {
       // Headers are here because something needs to be fixed in the service endpoint

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -21,8 +21,12 @@ export class RoutesClient {
    */
   async fetch(sources: LatLngIdTravelMode[], targets: LatLngId[], options: RouteRequestOptions): Promise<Route[]> {
     const cfg = new RouteRequestPayload(this.client, sources, targets, options)
-    const url = UrlUtil.buildTargomoUrl(this.client.serviceUrl, 'v' + this.client.config.version + '/route',
-      this.client.serviceKey) + '&cfg=' + encodeURIComponent(JSON.stringify(cfg))
+    const url = UrlUtil.buildTargomoUrl(
+      this.client.serviceUrl,
+      (this.client.config.version !== null && this.client.config.version !== undefined ? 'v' + this.client.config.version + '/' : '') +
+      'route',
+      this.client.serviceKey
+    ) + '&cfg=' + encodeURIComponent(JSON.stringify(cfg))
     const result = await requests(this.client, options).fetchCachedData(options.useClientCache, url, 'GET', undefined, {
       // Headers are here because something needs to be fixed in the service endpoint
       'Accept': 'application/json,application/javascript,*/*'

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -26,7 +26,7 @@ export class RoutesClient {
     const url = new UrlUtil.TargomoUrl(this.client)
       .part(this.client.serviceUrl)
       .version()
-      .part('route')
+      .part('/route')
       .key()
       .params({
         cfg: encodeURIComponent(JSON.stringify(cfg))

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -21,12 +21,18 @@ export class RoutesClient {
    */
   async fetch(sources: LatLngIdTravelMode[], targets: LatLngId[], options: RouteRequestOptions): Promise<Route[]> {
     const cfg = new RouteRequestPayload(this.client, sources, targets, options)
-    const url = UrlUtil.buildTargomoUrl(
-      this.client.serviceUrl,
-      (this.client.config.version !== null && this.client.config.version !== undefined ? 'v' + this.client.config.version + '/' : '') +
-      'route',
-      this.client.serviceKey
-    ) + '&cfg=' + encodeURIComponent(JSON.stringify(cfg))
+
+
+    const url = new UrlUtil.TargomoUrl(this.client)
+      .part(this.client.serviceUrl)
+      .version()
+      .part('route')
+      .key()
+      .params({
+        cfg: encodeURIComponent(JSON.stringify(cfg))
+      })
+      .toString();
+
     const result = await requests(this.client, options).fetchCachedData(options.useClientCache, url, 'GET', undefined, {
       // Headers are here because something needs to be fixed in the service endpoint
       'Accept': 'application/json,application/javascript,*/*'

--- a/src/api/similarity.ts
+++ b/src/api/similarity.ts
@@ -53,10 +53,6 @@ export class SimilarityClient {
       }))
     }
 
-    const normalizeParam = (normalizeOnViewport ? `?normalizeOnViewport=${!!normalizeOnViewport}&` : '?')
-                            + `?key=${encodeURIComponent(this.client.serviceKey)}`
-
-
     const urlObject = new UrlUtil.TargomoUrl(this.client)
       .part(this.client.config.tilesUrl)
       .part('similarity/scores_cumulative')

--- a/src/api/similarity.ts
+++ b/src/api/similarity.ts
@@ -13,8 +13,8 @@ export class SimilarityClient {
   /**
    *
    */
-  async metadata(key: StatisticsGroupId, version: number = 1): Promise<any[]> {
-    const url = `${this.client.config.tilesUrl}/similarity/meta/v${version}/${encodeURIComponent('' + key)}`
+  async metadata(key: StatisticsGroupId): Promise<any[]> {
+    const url = `${this.client.config.tilesUrl}/similarity/meta/v${this.client.config.version}/${encodeURIComponent('' + key)}`
                  + `?key=${encodeURIComponent(this.client.serviceKey)}`
     return await requests(this.client).fetch(url)
   }
@@ -48,7 +48,8 @@ export class SimilarityClient {
 
     const normalizeParam = (normalizeOnViewport ? `?normalizeOnViewport=${!!normalizeOnViewport}&` : '?')
                             + `?key=${encodeURIComponent(this.client.serviceKey)}`
-    const url = `${this.client.config.tilesUrl}/similarity/scores_cumulative/v1/${encodeURIComponent('' + group)}${normalizeParam}`
+    const url = `${this.client.config.tilesUrl}/similarity/scores_cumulative/v${this.client.config.version}/` +
+    `${encodeURIComponent('' + group)}${normalizeParam}`
     return await requests(this.client).fetch(url, 'POST', data)
   }
 }

--- a/src/api/similarity.ts
+++ b/src/api/similarity.ts
@@ -13,8 +13,8 @@ export class SimilarityClient {
   /**
    *
    */
-  async metadata(key: StatisticsGroupId): Promise<any[]> {
-    const url = `${this.client.config.tilesUrl}/similarity/meta/v1/${encodeURIComponent('' + key)}`
+  async metadata(key: StatisticsGroupId, version: number = 1): Promise<any[]> {
+    const url = `${this.client.config.tilesUrl}/similarity/meta/v${version}/${encodeURIComponent('' + key)}`
                  + `?key=${encodeURIComponent(this.client.serviceKey)}`
     return await requests(this.client).fetch(url)
   }

--- a/src/api/similarity.ts
+++ b/src/api/similarity.ts
@@ -15,12 +15,13 @@ export class SimilarityClient {
    */
   async metadata(key: StatisticsGroupId): Promise<any[]> {
 
-    const url = UrlUtil.buildTargomoUrl(this.client.config.tilesUrl,
-      '/similarity/meta/' +
-      (this.client.config.version !== null && this.client.config.version !== undefined ? 'v' + this.client.config.version + '/' : '') +
-      encodeURIComponent('' + key),
-      this.client.serviceKey
-    );
+    const url = new UrlUtil.TargomoUrl(this.client)
+      .part(this.client.config.tilesUrl)
+      .part('similarity/meta')
+      .version()
+      .part(encodeURIComponent('' + key))
+      .key()
+      .toString();
 
     return await requests(this.client).fetch(url)
   }
@@ -55,10 +56,14 @@ export class SimilarityClient {
     const normalizeParam = (normalizeOnViewport ? `?normalizeOnViewport=${!!normalizeOnViewport}&` : '?')
                             + `?key=${encodeURIComponent(this.client.serviceKey)}`
 
-    const url = this.client.config.tilesUrl +
-    '/similarity/scores_cumulative/' +
-    (this.client.config.version !== null && this.client.config.version !== undefined ? 'v' + this.client.config.version + '/' : '') +
-    encodeURIComponent('' + group) + normalizeParam;
+
+    const urlObject = new UrlUtil.TargomoUrl(this.client)
+      .part(this.client.config.tilesUrl)
+      .part('similarity/scores_cumulative')
+      .version()
+      .part(encodeURIComponent('' + group))
+      .key();
+    const url = normalizeOnViewport ? urlObject.params({normalizeOnViewport: !!normalizeOnViewport}).toString() : urlObject.toString();
 
     return await requests(this.client).fetch(url, 'POST', data)
   }

--- a/src/api/similarity.ts
+++ b/src/api/similarity.ts
@@ -16,10 +16,10 @@ export class SimilarityClient {
   async metadata(key: StatisticsGroupId): Promise<any[]> {
 
     const url = new UrlUtil.TargomoUrl(this.client)
-      .part(this.client.config.tilesUrl)
-      .part('similarity/meta')
+      .host(this.client.config.tilesUrl)
+      .part('similarity/meta/')
       .version()
-      .part(encodeURIComponent('' + key))
+      .part('/' + encodeURIComponent('' + key))
       .key()
       .toString();
 
@@ -54,10 +54,10 @@ export class SimilarityClient {
     }
 
     const urlObject = new UrlUtil.TargomoUrl(this.client)
-      .part(this.client.config.tilesUrl)
-      .part('similarity/scores_cumulative')
+      .host(this.client.config.tilesUrl)
+      .part('similarity/scores_cumulative/')
       .version()
-      .part(encodeURIComponent('' + group))
+      .part('/' + encodeURIComponent('' + group))
       .key();
     const url = normalizeOnViewport ? urlObject.params({normalizeOnViewport: !!normalizeOnViewport}).toString() : urlObject.toString();
 

--- a/src/api/similarity.ts
+++ b/src/api/similarity.ts
@@ -1,5 +1,5 @@
 import { TargomoClient } from './targomoClient'
-import { StatisticsGroupId, SimilarityCriteria, BoundingBox } from '../index';
+import { StatisticsGroupId, SimilarityCriteria, BoundingBox, UrlUtil } from '../index';
 import { requests} from '../util/requestUtil';
 
 /**
@@ -14,8 +14,14 @@ export class SimilarityClient {
    *
    */
   async metadata(key: StatisticsGroupId): Promise<any[]> {
-    const url = `${this.client.config.tilesUrl}/similarity/meta/v${this.client.config.version}/${encodeURIComponent('' + key)}`
-                 + `?key=${encodeURIComponent(this.client.serviceKey)}`
+
+    const url = UrlUtil.buildTargomoUrl(this.client.config.tilesUrl,
+      '/similarity/meta/' +
+      (this.client.config.version !== null && this.client.config.version !== undefined ? 'v' + this.client.config.version + '/' : '') +
+      encodeURIComponent('' + key),
+      this.client.serviceKey
+    );
+
     return await requests(this.client).fetch(url)
   }
 
@@ -48,9 +54,12 @@ export class SimilarityClient {
 
     const normalizeParam = (normalizeOnViewport ? `?normalizeOnViewport=${!!normalizeOnViewport}&` : '?')
                             + `?key=${encodeURIComponent(this.client.serviceKey)}`
-    const url = `${this.client.config.tilesUrl}/similarity/scores_cumulative/v${this.client.config.version}/` +
-    `${encodeURIComponent('' + group)}${normalizeParam}`
+
+    const url = this.client.config.tilesUrl +
+    '/similarity/scores_cumulative/' +
+    (this.client.config.version !== null && this.client.config.version !== undefined ? 'v' + this.client.config.version + '/' : '') +
+    encodeURIComponent('' + group) + normalizeParam;
+
     return await requests(this.client).fetch(url, 'POST', data)
   }
 }
-

--- a/src/api/statefulMultigraph.ts
+++ b/src/api/statefulMultigraph.ts
@@ -19,7 +19,7 @@ export class StatefulMultigraphClient {
    * @param options
    */
   async create(sources: LatLngId[], options: MultigraphRequestOptions): Promise<number> {
-    const url = UrlUtil.buildTargomoUrl(this.client.config.statisticsUrl, 'multigraph', this.client.serviceKey, false)
+    const url = UrlUtil.buildTargomoUrl(this.client.config.statisticsUrl, 'multigraph', this.client.serviceKey)
     const cfg = new StatefulMultigraphRequestPayload(this.client, sources, options);
 
     const result = await requests(this.client, options)
@@ -40,7 +40,7 @@ export class StatefulMultigraphClient {
    * @param multigaphId Id of the multigraph
    */
   async info(multigaphId: number): Promise<MultigraphInfo> {
-    const url = UrlUtil.buildTargomoUrl(this.client.config.statisticsUrl, 'multigraph/' + multigaphId, this.client.serviceKey, false)
+    const url = UrlUtil.buildTargomoUrl(this.client.config.statisticsUrl, 'multigraph/' + multigaphId, this.client.serviceKey)
     const result = await requests(this.client).fetch(url, 'GET')
     if (result.boundingBoxNorthEast && result.boundingBoxSouthWest) {
       result.boundingBox = <BoundingBox>{
@@ -66,7 +66,7 @@ export class StatefulMultigraphClient {
    */
   async redo(multigaphId: number): Promise<void> {
     const url =
-      UrlUtil.buildTargomoUrl(this.client.config.statisticsUrl, 'multigraph/' + multigaphId + '/update', this.client.serviceKey, false)
+      UrlUtil.buildTargomoUrl(this.client.config.statisticsUrl, 'multigraph/' + multigaphId + '/update', this.client.serviceKey)
     const result = await requests(this.client).fetch(url, 'PATCH')
     return result
   }

--- a/src/api/statefulMultigraph.ts
+++ b/src/api/statefulMultigraph.ts
@@ -21,7 +21,7 @@ export class StatefulMultigraphClient {
   async create(sources: LatLngId[], options: MultigraphRequestOptions): Promise<number> {
 
     const url = new UrlUtil.TargomoUrl(this.client)
-      .part(this.client.config.statisticsUrl)
+      .host(this.client.config.statisticsUrl)
       .part('multigraph')
       .key()
       .toString();
@@ -47,7 +47,7 @@ export class StatefulMultigraphClient {
    */
   async info(multigaphId: number): Promise<MultigraphInfo> {
     const url = new UrlUtil.TargomoUrl(this.client)
-    .part(this.client.config.statisticsUrl)
+    .host(this.client.config.statisticsUrl)
     .part('multigraph/' + multigaphId)
     .key()
     .toString();
@@ -77,7 +77,7 @@ export class StatefulMultigraphClient {
    */
   async redo(multigaphId: number): Promise<void> {
     const url = new UrlUtil.TargomoUrl(this.client)
-      .part(this.client.config.statisticsUrl)
+      .host(this.client.config.statisticsUrl)
       .part('multigraph/' + multigaphId + '/update')
       .key()
       .toString();

--- a/src/api/statefulMultigraph.ts
+++ b/src/api/statefulMultigraph.ts
@@ -19,7 +19,13 @@ export class StatefulMultigraphClient {
    * @param options
    */
   async create(sources: LatLngId[], options: MultigraphRequestOptions): Promise<number> {
-    const url = UrlUtil.buildTargomoUrl(this.client.config.statisticsUrl, 'multigraph', this.client.serviceKey)
+
+    const url = new UrlUtil.TargomoUrl(this.client)
+      .part(this.client.config.statisticsUrl)
+      .part('multigraph')
+      .key()
+      .toString();
+
     const cfg = new StatefulMultigraphRequestPayload(this.client, sources, options);
 
     const result = await requests(this.client, options)
@@ -40,7 +46,12 @@ export class StatefulMultigraphClient {
    * @param multigaphId Id of the multigraph
    */
   async info(multigaphId: number): Promise<MultigraphInfo> {
-    const url = UrlUtil.buildTargomoUrl(this.client.config.statisticsUrl, 'multigraph/' + multigaphId, this.client.serviceKey)
+    const url = new UrlUtil.TargomoUrl(this.client)
+    .part(this.client.config.statisticsUrl)
+    .part('multigraph/' + multigaphId)
+    .key()
+    .toString();
+
     const result = await requests(this.client).fetch(url, 'GET')
     if (result.boundingBoxNorthEast && result.boundingBoxSouthWest) {
       result.boundingBox = <BoundingBox>{
@@ -65,8 +76,12 @@ export class StatefulMultigraphClient {
    * @param multigaphId
    */
   async redo(multigaphId: number): Promise<void> {
-    const url =
-      UrlUtil.buildTargomoUrl(this.client.config.statisticsUrl, 'multigraph/' + multigaphId + '/update', this.client.serviceKey)
+    const url = new UrlUtil.TargomoUrl(this.client)
+      .part(this.client.config.statisticsUrl)
+      .part('multigraph/' + multigaphId + '/update')
+      .key()
+      .toString();
+
     const result = await requests(this.client).fetch(url, 'PATCH')
     return result
   }

--- a/src/api/statistics.spec.ts
+++ b/src/api/statistics.spec.ts
@@ -2,7 +2,7 @@ import { StatisticsGroups } from '../index';
 import { TargomoClient } from './targomoClient';
 
 describe('TargomoClient statistics service', () => {
-  const testClient = new TargomoClient('germany', process.env.TGM_TEST_API_KEY)
+  const testClient = new TargomoClient('westcentraleurope', process.env.TGM_TEST_API_KEY)
 
   test('statistic service request', async () => {
     const sources = [{ lng: 13.3786431, lat: 52.4668237, id: 1}]

--- a/src/api/statistics.spec.ts
+++ b/src/api/statistics.spec.ts
@@ -37,7 +37,7 @@ describe('TargomoClient statistics service', () => {
 
   test('get ensemble metadata', async () => {
     const testClient2 = new TargomoClient('germany', process.env.TGM_TEST_API_KEY, {
-      tilesUrl: 'https://api.targomo.com/vector-statistics-2'
+      tilesUrl: 'https://api.targomo.com/vector-statistics-2/'
     })
 
     const result = await testClient2.statistics.ensembles()

--- a/src/api/statistics.ts
+++ b/src/api/statistics.ts
@@ -101,14 +101,15 @@ export class StatisticsClient {
    *
    * @param group
    */
-  async metadata(group: StatisticsGroupMeta | StatisticsGroupId, version: number = 1) {
+  async metadata(group: StatisticsGroupMeta | StatisticsGroupId) {
     const server = this.client.config.tilesUrl
     const key = (typeof group == 'number') ? group : group.id
     const cacheKey = server + '-' + key
 
     return await this.statisticsMetadataCache.get(cacheKey, async () => {
       const result = await requests(this.client)
-                     .fetch(`${server}/statistics/meta/v${version}/${key}?key=${encodeURIComponent(this.client.serviceKey)}`)
+                     .fetch(`${server}/statistics/meta/v${this.client.config.version}/` +
+                     `${key}?key=${encodeURIComponent(this.client.serviceKey)}`)
       if (!result.name && result.names && result.names.en) {
         result.name = result.names.en
       }
@@ -143,7 +144,7 @@ export class StatisticsClient {
   /**
    * Potentially decorate a layer route with excluded statistics.
    */
-  tileRoute(group: StatisticsGroupMeta | StatisticsGroupId, include?: StatisticsItem[], version: number = 1) {
+  tileRoute(group: StatisticsGroupMeta | StatisticsGroupId, include?: StatisticsItem[]) {
     const server = this.client.config.tilesUrl
     const key = (typeof group == 'number') ? group : group.id
 
@@ -152,7 +153,8 @@ export class StatisticsClient {
     if (include && include.length > 0) {
       includeParam = 'columns=' + encodeURIComponent(include.map(row => +row.id).join(',')) + '&'
     }
-    return `${server}/statistics/tiles/v${version}/${key}/{z}/{x}/{y}.mvt?${includeParam}key=${encodeURIComponent(this.client.serviceKey)}`
+    return `${server}/statistics/tiles/v${this.client.config.version}/` +
+    `${key}/{z}/{x}/{y}.mvt?${includeParam}key=${encodeURIComponent(this.client.serviceKey)}`
   }
 
   /**
@@ -160,11 +162,12 @@ export class StatisticsClient {
    * @param sources
    * @param options
    */
-  async ensembles(version: number = 1): Promise<{[id: string]: StatisticsGroupEnsemble}> {
+  async ensembles(): Promise<{[id: string]: StatisticsGroupEnsemble}> {
     const cacheKey = this.client.config.tilesUrl
 
     return await this.statisticsEnsemblesCache.get(cacheKey, async () => {
-      const url = this.client.config.tilesUrl + '/ensemble/list/v' + version + '?key=' + encodeURIComponent(this.client.serviceKey)
+      const url = this.client.config.tilesUrl + '/ensemble/list/v' + this.client.config.version +
+      '?key=' + encodeURIComponent(this.client.serviceKey)
       const result = await requests(this.client).fetch(url, 'GET')
 
       // FIXME: workaround for server results

--- a/src/api/statistics.ts
+++ b/src/api/statistics.ts
@@ -59,7 +59,14 @@ export class StatisticsClient {
       return null
     }
 
-    const url = this.client.config.statisticsUrl + '/traveltimes?serviceUrl=' + encodeURIComponent(this.client.serviceUrl)
+    const url = new UrlUtil.TargomoUrl(this.client)
+      .part(this.client.config.statisticsUrl)
+      .part('traveltimes')
+      .params({
+        serviceUrl: this.client.serviceUrl
+      })
+      .toString();
+
     return await requests(this.client, options).fetch(url, 'POST', new StatisticsRequestPayload(this.client, sources, options))
   }
 
@@ -75,7 +82,14 @@ export class StatisticsClient {
       return null
     }
 
-    const url = this.client.config.statisticsUrl + '/charts/dependent?serviceUrl=' + encodeURIComponent(this.client.serviceUrl)
+    const url = new UrlUtil.TargomoUrl(this.client)
+      .part(this.client.config.statisticsUrl)
+      .part('charts/dependent')
+      .params({
+        serviceUrl: this.client.serviceUrl
+      })
+      .toString();
+
     const result = await requests(this.client, options)
       .fetch(url, 'POST', new StatisticsRequestPayload(this.client, sources, options))
     return new StatisticsResult(result, options.statistics)
@@ -92,7 +106,14 @@ export class StatisticsClient {
       return null
     }
 
-    const url = this.client.config.statisticsUrl + '/values/geometry?serviceUrl=' + encodeURIComponent(this.client.serviceUrl)
+    const url = new UrlUtil.TargomoUrl(this.client)
+      .part(this.client.config.statisticsUrl)
+      .part('values/geometry')
+      .params({
+        serviceUrl: this.client.serviceUrl
+      })
+      .toString();
+
     const result = await requests(this.client, options)
     .fetch(url, 'POST', new StatisticsGeometryRequestPayload(this.client, geometry, options))
     return new StatisticsGeometryResult(result, options.statistics)
@@ -109,13 +130,13 @@ export class StatisticsClient {
 
     return await this.statisticsMetadataCache.get(cacheKey, async () => {
 
-      const url = UrlUtil.buildTargomoUrl(this.client.config.tilesUrl,
-        '/statistics/meta/' +
-        (this.client.config.version !== null && this.client.config.version !== undefined ? 'v' + this.client.config.version + '/' : '') +
-        key,
-        this.client.serviceKey
-      );
-
+      const url = new UrlUtil.TargomoUrl(this.client)
+        .part(this.client.config.tilesUrl)
+        .part('statistics/meta')
+        .version()
+        .part(key + '')
+        .key()
+        .toString();
 
       const result = await requests(this.client).fetch(url)
       if (!result.name && result.names && result.names.en) {
@@ -155,19 +176,16 @@ export class StatisticsClient {
   tileRoute(group: StatisticsGroupMeta | StatisticsGroupId, include?: StatisticsItem[]) {
     const key = (typeof group == 'number') ? group : group.id
 
-    let includeParam = ''
+    const urlObject = new UrlUtil.TargomoUrl(this.client)
+      .part(this.client.config.tilesUrl)
+      .part('statistics/tiles')
+      .version()
+      .part(key + '/{z}/{x}/{y}.mvt')
+      .key();
 
-    if (include && include.length > 0) {
-      includeParam = '&columns=' + encodeURIComponent(include.map(row => +row.id).join(','))
-    }
-
-    return UrlUtil.buildTargomoUrl(
-      this.client.config.tilesUrl,
-      'statistics/tiles/' +
-      (this.client.config.version !== null && this.client.config.version !== undefined ? 'v' + this.client.config.version + '/' : '') +
-      key + '/{z}/{x}/{y}.mvt',
-      this.client.serviceKey
-    ) + includeParam;
+    return include && include.length > 0 ?
+      urlObject.params({columns: encodeURIComponent(include.map(row => +row.id).join(','))}).toString() :
+      urlObject.toString()
 
   }
 
@@ -181,12 +199,12 @@ export class StatisticsClient {
 
     return await this.statisticsEnsemblesCache.get(cacheKey, async () => {
 
-      const url = UrlUtil.buildTargomoUrl(this.client.config.tilesUrl,
-        '/ensemble/list/' +
-        (this.client.config.version !== null && this.client.config.version !== undefined ? 'v' + this.client.config.version : ''),
-        this.client.serviceKey
-      );
-
+      const url = new UrlUtil.TargomoUrl(this.client)
+        .part(this.client.config.tilesUrl)
+        .part('ensemble/list')
+        .version()
+        .key()
+        .toString();
 
       const result = await requests(this.client).fetch(url, 'GET')
 

--- a/src/api/statistics.ts
+++ b/src/api/statistics.ts
@@ -60,7 +60,7 @@ export class StatisticsClient {
     }
 
     const url = new UrlUtil.TargomoUrl(this.client)
-      .part(this.client.config.statisticsUrl)
+      .host(this.client.config.statisticsUrl)
       .part('traveltimes')
       .params({
         serviceUrl: this.client.serviceUrl
@@ -83,7 +83,7 @@ export class StatisticsClient {
     }
 
     const url = new UrlUtil.TargomoUrl(this.client)
-      .part(this.client.config.statisticsUrl)
+      .host(this.client.config.statisticsUrl)
       .part('charts/dependent')
       .params({
         serviceUrl: this.client.serviceUrl
@@ -107,7 +107,7 @@ export class StatisticsClient {
     }
 
     const url = new UrlUtil.TargomoUrl(this.client)
-      .part(this.client.config.statisticsUrl)
+      .host(this.client.config.statisticsUrl)
       .part('values/geometry')
       .params({
         serviceUrl: this.client.serviceUrl
@@ -131,10 +131,10 @@ export class StatisticsClient {
     return await this.statisticsMetadataCache.get(cacheKey, async () => {
 
       const url = new UrlUtil.TargomoUrl(this.client)
-        .part(this.client.config.tilesUrl)
-        .part('statistics/meta')
+        .host(this.client.config.tilesUrl)
+        .part('statistics/meta/')
         .version()
-        .part(key + '')
+        .part('/' + key + '')
         .key()
         .toString();
 
@@ -177,10 +177,10 @@ export class StatisticsClient {
     const key = (typeof group == 'number') ? group : group.id
 
     const urlObject = new UrlUtil.TargomoUrl(this.client)
-      .part(this.client.config.tilesUrl)
-      .part('statistics/tiles')
+      .host(this.client.config.tilesUrl)
+      .part('statistics/tiles/')
       .version()
-      .part(key + '/{z}/{x}/{y}.mvt')
+      .part('/' + key + '/{z}/{x}/{y}.mvt')
       .key();
 
     return include && include.length > 0 ?
@@ -200,8 +200,8 @@ export class StatisticsClient {
     return await this.statisticsEnsemblesCache.get(cacheKey, async () => {
 
       const url = new UrlUtil.TargomoUrl(this.client)
-        .part(this.client.config.tilesUrl)
-        .part('ensemble/list')
+        .host(this.client.config.tilesUrl)
+        .part('ensemble/list/')
         .version()
         .key()
         .toString();

--- a/src/api/statistics.ts
+++ b/src/api/statistics.ts
@@ -101,14 +101,14 @@ export class StatisticsClient {
    *
    * @param group
    */
-  async metadata(group: StatisticsGroupMeta | StatisticsGroupId) {
+  async metadata(group: StatisticsGroupMeta | StatisticsGroupId, version: number = 1) {
     const server = this.client.config.tilesUrl
     const key = (typeof group == 'number') ? group : group.id
     const cacheKey = server + '-' + key
 
     return await this.statisticsMetadataCache.get(cacheKey, async () => {
       const result = await requests(this.client)
-                     .fetch(`${server}/statistics/meta/v1/${key}?key=${encodeURIComponent(this.client.serviceKey)}`)
+                     .fetch(`${server}/statistics/meta/v${version}/${key}?key=${encodeURIComponent(this.client.serviceKey)}`)
       if (!result.name && result.names && result.names.en) {
         result.name = result.names.en
       }
@@ -143,7 +143,7 @@ export class StatisticsClient {
   /**
    * Potentially decorate a layer route with excluded statistics.
    */
-  tileRoute(group: StatisticsGroupMeta | StatisticsGroupId, include?: StatisticsItem[]) {
+  tileRoute(group: StatisticsGroupMeta | StatisticsGroupId, include?: StatisticsItem[], version: number = 1) {
     const server = this.client.config.tilesUrl
     const key = (typeof group == 'number') ? group : group.id
 
@@ -152,7 +152,7 @@ export class StatisticsClient {
     if (include && include.length > 0) {
       includeParam = 'columns=' + encodeURIComponent(include.map(row => +row.id).join(',')) + '&'
     }
-    return `${server}/statistics/tiles/v1/${key}/{z}/{x}/{y}.mvt?${includeParam}key=${encodeURIComponent(this.client.serviceKey)}`
+    return `${server}/statistics/tiles/v${version}/${key}/{z}/{x}/{y}.mvt?${includeParam}key=${encodeURIComponent(this.client.serviceKey)}`
   }
 
   /**
@@ -160,11 +160,11 @@ export class StatisticsClient {
    * @param sources
    * @param options
    */
-  async ensembles(): Promise<{[id: string]: StatisticsGroupEnsemble}> {
+  async ensembles(version: number = 1): Promise<{[id: string]: StatisticsGroupEnsemble}> {
     const cacheKey = this.client.config.tilesUrl
 
     return await this.statisticsEnsemblesCache.get(cacheKey, async () => {
-      const url = this.client.config.tilesUrl + '/ensemble/list/v1?key=' + encodeURIComponent(this.client.serviceKey)
+      const url = this.client.config.tilesUrl + '/ensemble/list/v' + version + '?key=' + encodeURIComponent(this.client.serviceKey)
       const result = await requests(this.client).fetch(url, 'GET')
 
       // FIXME: workaround for server results

--- a/src/api/targomoClient.ts
+++ b/src/api/targomoClient.ts
@@ -103,11 +103,12 @@ export class TargomoClient {
    */
   async metadata() {
 
-    const url = UrlUtil.buildTargomoUrl(this.serviceUrl,
-      (this.config.version !== null && this.config.version !== undefined ? 'v' + this.config.version + '/' : '') +
-      'metadata/network',
-      this.serviceKey
-    );
+    const url = new UrlUtil.TargomoUrl(this)
+      .part(this.serviceUrl)
+      .version()
+      .part('metadata/network')
+      .key()
+      .toString();
 
     return await requests(this).fetch(url)
   }

--- a/src/api/targomoClient.ts
+++ b/src/api/targomoClient.ts
@@ -106,7 +106,7 @@ export class TargomoClient {
     const url = new UrlUtil.TargomoUrl(this)
       .part(this.serviceUrl)
       .version()
-      .part('metadata/network')
+      .part('/metadata/network')
       .key()
       .toString();
 

--- a/src/api/targomoClient.ts
+++ b/src/api/targomoClient.ts
@@ -101,7 +101,6 @@ export class TargomoClient {
    *
    */
   async metadata() {
-    const endpoint = this.endpoint
     const key = this.serviceKey
     const url = `${this.serviceUrl}metadata/network?key=${encodeURIComponent(key)}`
     return await requests(this).fetch(url)

--- a/src/api/targomoClient.ts
+++ b/src/api/targomoClient.ts
@@ -63,7 +63,7 @@ export class TargomoClient {
     this.config = new ClientConfig(options)
 
     if (!region.includes('http') && !region.includes('localhost') && !region.includes('/')) {
-      this.serviceUrl = 'https://api.targomo.com/' + region + '/v1/'
+      this.serviceUrl = 'https://api.targomo.com/' + region + '/v' + this.config.version + '/'
     } else {
       this.serviceUrl = region
     }

--- a/src/api/targomoClient.ts
+++ b/src/api/targomoClient.ts
@@ -63,7 +63,7 @@ export class TargomoClient {
     this.config = new ClientConfig(options)
 
     if (!region.includes('http') && !region.includes('localhost') && !region.includes('/')) {
-      this.serviceUrl = 'https://api.targomo.com/' + region + '/v' + this.config.version + '/'
+      this.serviceUrl = 'https://api.targomo.com/' + region + '/'
     } else {
       this.serviceUrl = region
     }
@@ -102,7 +102,7 @@ export class TargomoClient {
    */
   async metadata() {
     const key = this.serviceKey
-    const url = `${this.serviceUrl}metadata/network?key=${encodeURIComponent(key)}`
+    const url = `${this.serviceUrl}v${this.config.version}/metadata/network?key=${encodeURIComponent(key)}`
     return await requests(this).fetch(url)
   }
 }

--- a/src/api/targomoClient.ts
+++ b/src/api/targomoClient.ts
@@ -15,6 +15,7 @@ import { StatefulMultigraphClient } from './statefulMultigraph';
 import { FleetsClient } from './fleets';
 import { MultigraphClient } from './multigraph';
 import { BasemapsClient } from './basemaps';
+import { UrlUtil } from '..';
 
 /**
  * @Topic Geocoding
@@ -101,8 +102,13 @@ export class TargomoClient {
    *
    */
   async metadata() {
-    const key = this.serviceKey
-    const url = `${this.serviceUrl}v${this.config.version}/metadata/network?key=${encodeURIComponent(key)}`
+
+    const url = UrlUtil.buildTargomoUrl(this.serviceUrl,
+      (this.config.version !== null && this.config.version !== undefined ? 'v' + this.config.version + '/' : '') +
+      'metadata/network',
+      this.serviceKey
+    );
+
     return await requests(this).fetch(url)
   }
 }

--- a/src/api/targomoClient.ts
+++ b/src/api/targomoClient.ts
@@ -63,7 +63,7 @@ export class TargomoClient {
     this.config = new ClientConfig(options)
 
     if (!region.includes('http') && !region.includes('localhost') && !region.includes('/')) {
-      this.serviceUrl = 'https://api.targomo.com/' + region + '/'
+      this.serviceUrl = 'https://api.targomo.com/' + region + '/v1/'
     } else {
       this.serviceUrl = region
     }
@@ -103,7 +103,7 @@ export class TargomoClient {
   async metadata() {
     const endpoint = this.endpoint
     const key = this.serviceKey
-    const url = `${this.config.serverUrl}/${endpoint}/v1/metadata/network?key=${encodeURIComponent(key)}`
+    const url = `${this.serviceUrl}metadata/network?key=${encodeURIComponent(key)}`
     return await requests(this).fetch(url)
   }
 }

--- a/src/types/options/multigraphRequestOptions.ts
+++ b/src/types/options/multigraphRequestOptions.ts
@@ -27,7 +27,7 @@ export interface MultigraphSpecificRequestOptions {
     ignoreOutliers?: boolean
     outlierPenalty?: number
     minSourcesRatio?: number
-    minSourceCount?: number
+    minSourcesCount?: number
     maxResultValue?: number
     maxResultValueRatio?: number
     filterValuesForSourceOrigins?: string[]

--- a/src/util/urlUtil.spec.ts
+++ b/src/util/urlUtil.spec.ts
@@ -24,6 +24,17 @@ describe('Url Util tests', () => {
     new UrlUtil.TargomoUrl(client2).part(client2.serviceUrl).version().part('/test/test').key().params(sampleParams).toString();
     expect(queryString2).toEqual('http://other.url/asdf/test/test?key=aaa&search=foo&auth=bar&key=baz');
 
+
+    const sampleParams2 = {
+      test: [1, 2, 3]
+    }
+
+    const client3 = new TargomoClient('http://other.url/asdf/', 'aaa', {version: null});
+
+    const queryString3 =
+    new UrlUtil.TargomoUrl(client3).part(client3.serviceUrl).version().part('/test/test').key().params(sampleParams2).toString();
+    expect(queryString3).toEqual('http://other.url/asdf/test/test?key=aaa&test=1&test=2&test=3');
+
   })
 
 })

--- a/src/util/urlUtil.spec.ts
+++ b/src/util/urlUtil.spec.ts
@@ -1,4 +1,5 @@
 import {UrlUtil} from './urlUtil'
+import { TargomoClient } from '..';
 
 describe('Url Util tests', () => {
 
@@ -10,9 +11,12 @@ describe('Url Util tests', () => {
       key: 'baz'
     }
 
-    const queryString = UrlUtil.queryToString(sampleParams)
+    const client = new TargomoClient('westcentraleurope', 'aaa', {version: 2});
 
-    expect(queryString.indexOf('&')).toBeGreaterThan(0)
+    const queryString =
+    new UrlUtil.TargomoUrl(client).part(client.serviceUrl).version().part('test/test').key().params(sampleParams).toString();
+
+    expect(queryString).toEqual('https://api.targomo.com/westcentraleurope/v2/test/test?key=aaa&search=foo&auth=bar&key=baz');
 
   })
 

--- a/src/util/urlUtil.spec.ts
+++ b/src/util/urlUtil.spec.ts
@@ -14,9 +14,15 @@ describe('Url Util tests', () => {
     const client = new TargomoClient('westcentraleurope', 'aaa', {version: 2});
 
     const queryString =
-    new UrlUtil.TargomoUrl(client).part(client.serviceUrl).version().part('test/test').key().params(sampleParams).toString();
+    new UrlUtil.TargomoUrl(client).part(client.serviceUrl).version().part('/test/test').key().params(sampleParams).toString();
 
     expect(queryString).toEqual('https://api.targomo.com/westcentraleurope/v2/test/test?key=aaa&search=foo&auth=bar&key=baz');
+
+    const client2 = new TargomoClient('http://other.url/asdf/', 'aaa', {version: null});
+
+    const queryString2 =
+    new UrlUtil.TargomoUrl(client2).part(client2.serviceUrl).version().part('/test/test').key().params(sampleParams).toString();
+    expect(queryString2).toEqual('http://other.url/asdf/test/test?key=aaa&search=foo&auth=bar&key=baz');
 
   })
 

--- a/src/util/urlUtil.ts
+++ b/src/util/urlUtil.ts
@@ -13,11 +13,11 @@ export namespace UrlUtil {
     return result.join('&')
   }
 
-  export function buildTargomoUrl(serviceUrl: string, service: string, serviceKey: string, versionFlag: boolean = true) {
+  export function buildTargomoUrl(serviceUrl: string, service: string, serviceKey: string) {
     if (serviceUrl[serviceUrl.length - 1] !== '/') {
       serviceUrl += '/'
     }
-    return serviceUrl + (versionFlag ? 'v1/' : '') + service + '?key=' + serviceKey
+    return serviceUrl + service + '?key=' + serviceKey
   }
 
 }

--- a/src/util/urlUtil.ts
+++ b/src/util/urlUtil.ts
@@ -32,18 +32,26 @@ export namespace UrlUtil {
     }
 
     params(value: any) {
-
       const keys = Object.keys(value);
       keys.forEach(key => {
-        if (!this.firstParamPlaced) {
-          this.firstParamPlaced = true;
-          this.url += '?' + key + '=' + value[key];
+        if (value[key] instanceof Array) {
+          value[key].forEach((v: any) => {
+            this.param(key, v);
+          });
         } else {
-          this.url += '&' + key + '=' + value[key];
+          this.param(key, value[key]);
         }
       });
-
       return this;
+    }
+
+    private param(name: string, value: any) {
+      if (!this.firstParamPlaced) {
+        this.firstParamPlaced = true;
+        this.url += '?' + name + '=' + value;
+      } else {
+        this.url += '&' + name + '=' + value;
+      }
     }
 
     key() {

--- a/src/util/urlUtil.ts
+++ b/src/util/urlUtil.ts
@@ -8,28 +8,30 @@ export namespace UrlUtil {
 
     constructor(private client?: TargomoClient) { }
 
-    part(value: string) {
-      if (value[0] === '/') {
-        value = value.substr(1, value.length - 2);
-      }
-      if (value[value.length - 1] !== '/') {
+
+    host(value: string) {
+      if (this.url.length === 0 && value[value.length - 1] !== '/') {
         value += '/';
       }
-      this.url += value;
+      return this.part(value);
+    }
 
+    part(value: string) {
+      this.url += value;
       return this;
     }
 
     version() {
-      this.url +=
-        this.client.config.version !== null && this.client.config.version !== undefined ? 'v' + this.client.config.version + '/' : '';
+      if (this.client.config.version !== null && this.client.config.version !== undefined) {
+        this.part('v' + this.client.config.version);
+      } else if (this.url[this.url.length - 1] === '/' ) {
+        this.url = this.url.substr(0, this.url.length - 1);
+      }
+
       return this;
     }
 
     params(value: any) {
-      if (this.url[this.url.length - 1] === '/') {
-        this.url = this.url.substr(0, this.url.length - 1);
-      }
 
       const keys = Object.keys(value);
       keys.forEach(key => {

--- a/src/util/urlUtil.ts
+++ b/src/util/urlUtil.ts
@@ -1,24 +1,56 @@
+import { TargomoClient } from '..';
+
 export namespace UrlUtil {
 
-  export function queryToString(params: any) {
-    const result: string[] = []
+  export class TargomoUrl {
+    private url = '';
+    private firstParamPlaced = false;
 
-    for (const key in params) {
-      const value = params[key]
-      if (value !== undefined) {
-        result.push(`${key}=${encodeURIComponent(value)}`)
+    constructor(private client?: TargomoClient) { }
+
+    part(value: string) {
+      if (value[0] === '/') {
+        value = value.substr(1, value.length - 2);
       }
+      if (value[value.length - 1] !== '/') {
+        value += '/';
+      }
+      this.url += value;
+
+      return this;
     }
 
-    return result.join('&')
-  }
-
-  export function buildTargomoUrl(serviceUrl: string, service: string, serviceKey: string) {
-    if (serviceUrl[serviceUrl.length - 1] !== '/') {
-      serviceUrl += '/'
+    version() {
+      this.url +=
+        this.client.config.version !== null && this.client.config.version !== undefined ? 'v' + this.client.config.version + '/' : '';
+      return this;
     }
-    return serviceUrl + service + '?key=' + serviceKey
-  }
 
+    params(value: any) {
+      if (this.url[this.url.length - 1] === '/') {
+        this.url = this.url.substr(0, this.url.length - 1);
+      }
+
+      const keys = Object.keys(value);
+      keys.forEach(key => {
+        if (!this.firstParamPlaced) {
+          this.firstParamPlaced = true;
+          this.url += '?' + key + '=' + value[key];
+        } else {
+          this.url += '&' + key + '=' + value[key];
+        }
+      });
+
+      return this;
+    }
+
+    key() {
+      return this.params({key: this.client.serviceKey});
+    }
+
+    toString(): string {
+      return this.url;
+    }
+  }
 }
 


### PR DESCRIPTION
- fixed property names in the multigraph model (minSourcesCount) and the property "elevationEnabled" (which should be simply "elevation")
- changed how urls are build. so that a "v1" flag is not always added after the service url when using a custom url