### PR TITLE
Stateful Multigraph: Implement full support 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@targomo/core",
-  "version": "0.2.14",
+  "version": "0.2.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@targomo/core",
   "description": "The JavaScript (& TypeScript) API for Targomo's time-based access mapping services.",
   "author": "Targomo",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "license": "MIT",
   "repository": "github:targomo/targomo-js",
   "homepage": "https://targomo.com/developers",

--- a/src/api/payload/statefulMultigraphRequestPayload.ts
+++ b/src/api/payload/statefulMultigraphRequestPayload.ts
@@ -1,26 +1,48 @@
 import { StatisticsRequestPayload } from './statisticsRequestPayload';
-import { LatLngId, MultigraphRequestOptions, MultigraphRequestAggregation} from '../../types';
+import { LatLngId, MultigraphRequestOptions, MultigraphRequestAggregation, MultigraphAggregationOptions} from '../../types';
 import { TargomoClient } from '../targomoClient';
 
 export class StatefulMultigraphRequestPayload extends StatisticsRequestPayload {
-  multiGraphSerializationType: 'geojson' | 'json' | 'mvt';
-  multiGraphSerializationDecimalPrecision: number;
-  multiGraphSerializationMaxGeometryCount: number;
 
-  /**
-   * not yet supported in the stateful version
-  multiGraphLayerType: 'edge' | 'node' | 'tile' | 'tile_node' | 'hexagon' | 'hexagon_node';
-  multiGraphLayerEdgeAggregationType: 'min' | 'max' | 'mean';
-  multiGraphLayerGeometryDetailPerTile: number;
-  multiGraphLayerMinGeometryDetailLevel: number;
-  multiGraphLayerMaxGeometryDetailLevel: number;
-  */
+  multiGraphPreAggregationPipeline: {
+    [pipelineName: string]: MultigraphAggregationOptions
+  }
+
+  multiGraphReferencedStatisticIds: {
+    [parameterName: string]: number
+  }
+
   multiGraphAggregationType: MultigraphRequestAggregation;
-  multiGraphAggregationIgnoreOutlier: boolean;
-  multiGraphAggregationMinSourcesRatio: number;
-  multiGraphAggregationMinSourcesCount: number;
-  multiGraphAggregationMaxResultValueRatio: number;
-  multiGraphAggregationMaxResultValue: number;
+  multiGraphAggregationIgnoreOutlier: boolean
+  multiGraphAggregationOutlierPenalty: number
+  multiGraphAggregationMinSourcesRatio: number
+  multiGraphAggregationMinSourcesCount: number
+  multiGraphAggregationMaxResultValueRatio: number
+  multiGraphAggregationMaxResultValue: number
+  multiGraphAggregationFilterValuesForSourceOrigins: string[]
+  multiGraphAggregationInputParameters: {
+    [parameterName: string]: {
+      inputFactor?: number
+      gravitationAttractionStrength?: number
+      gravitationPositiveInfluence?: number
+    }
+  }
+
+
+  multiGraphSerializationFormat: 'geojson' | 'json' | 'mvt'
+  multiGraphSerializationDecimalPrecision: number
+  multiGraphSerializationMaxGeometryCount: number
+
+  multiGraphDomainType: 'edge' | 'node' | 'statistic_geometry'
+  multiGraphDomainEdgeAggregationType: 'min' | 'max' | 'mean'
+  multiGraphDomainStatisticGroupId: number
+
+  multiGraphLayerType: 'identity' | 'tile' | 'hexagon' | 'custom_geometries'
+  multiGraphLayerGeometryDetailPerTile: number
+  multiGraphLayerMinGeometryDetailLevel: number
+  multiGraphLayerMaxGeometryDetailLevel: number
+  multiGraphLayerGeometryDetailLevel: number
+  multiGraphLayerCustomGeometryMergeAggregation: 'max' | 'mean' | 'min' | 'sum'
 
   constructor(client: TargomoClient, sources: LatLngId[], options: MultigraphRequestOptions) {
     super(client, sources, <any>options)
@@ -33,25 +55,42 @@ export class StatefulMultigraphRequestPayload extends StatisticsRequestPayload {
     delete this.useCache
 
     if (options) {
-      this.multiGraphSerializationType = options.multigraph.serialization.format
-      this.multiGraphSerializationDecimalPrecision = options.multigraph.serialization.decimalPrecision
-      /**
-       * not yet supported in the stateful version
-      if (options.layer) {
-        this.multiGraphLayerType = options.layer.type
-        this.multiGraphLayerEdgeAggregationType = options.layer.edgeAggregationType
-        this.multiGraphLayerGeometryDetailPerTile = options.layer.geometryDetailPerTile
-        this.multiGraphLayerMinGeometryDetailLevel = options.layer.minGeometryDetailLevel
-        this.multiGraphLayerMaxGeometryDetailLevel = options.layer.maxGeometryDetailLevel
+
+      if (options.multigraph.preAggregationPipeline) {
+        this.multiGraphPreAggregationPipeline = options.multigraph.preAggregationPipeline
       }
-      */
+
+      if (options.multigraph.referencedStatisticIds) {
+        this.multiGraphReferencedStatisticIds = options.multigraph.referencedStatisticIds
+      }
+
       if (options.multigraph.aggregation) {
         this.multiGraphAggregationType = options.multigraph.aggregation.type || null
         this.multiGraphAggregationIgnoreOutlier = options.multigraph.aggregation.ignoreOutliers || null
+        this.multiGraphAggregationOutlierPenalty = options.multigraph.aggregation.outlierPenalty || null
         this.multiGraphAggregationMinSourcesRatio = options.multigraph.aggregation.minSourcesRatio || null
         this.multiGraphAggregationMinSourcesCount = options.multigraph.aggregation.minSourcesCount || null
         this.multiGraphAggregationMaxResultValueRatio = options.multigraph.aggregation.maxResultValueRatio || null
         this.multiGraphAggregationMaxResultValue = options.multigraph.aggregation.maxResultValue || null
+        this.multiGraphAggregationFilterValuesForSourceOrigins = options.multigraph.aggregation.filterValuesForSourceOrigins || null
+        this.multiGraphAggregationInputParameters = options.multigraph.aggregation.aggregationInputParameters || null
+      }
+
+      this.multiGraphSerializationFormat = options.multigraph.serialization.format
+      this.multiGraphSerializationDecimalPrecision = options.multigraph.serialization.decimalPrecision
+      this.multiGraphSerializationMaxGeometryCount = options.multigraph.serialization.maxGeometryCount
+
+      this.multiGraphDomainType = options.multigraph.domain.type
+      this.multiGraphDomainEdgeAggregationType = options.multigraph.domain.edgeAggregationType
+      this.multiGraphDomainStatisticGroupId = options.multigraph.domain.statisticGroupId
+
+      if (options.multigraph.layer) {
+        this.multiGraphLayerType = options.multigraph.layer.type
+        this.multiGraphLayerGeometryDetailPerTile = options.multigraph.layer.geometryDetailPerTile
+        this.multiGraphLayerMinGeometryDetailLevel = options.multigraph.layer.minGeometryDetailLevel
+        this.multiGraphLayerMaxGeometryDetailLevel = options.multigraph.layer.maxGeometryDetailLevel
+        this.multiGraphLayerGeometryDetailLevel = options.multigraph.layer.geometryDetailLevel
+        this.multiGraphLayerCustomGeometryMergeAggregation = options.multigraph.layer.customGeometryMergeAggregation
       }
     }
   }

--- a/src/api/pointsOfInterest.ts
+++ b/src/api/pointsOfInterest.ts
@@ -70,7 +70,8 @@ export class PointsOfInterestClient {
    * @param query
    */
   async queryRaw(query: string): Promise<OSMLatLng[]> {
-    const result = await requests(this.client).fetch(this.client.config.overpassUrl + '/api/interpreter', 'POST-RAW', query)
+    let result = await requests(this.client).fetch(this.client.config.overpassUrl + '/api/interpreter', 'POST-RAW', query)
+    result = JSON.parse(result)
     return result.elements.filter((item: any) => !!item.tags).map((item: any) => parseOSMLocation(item))
   }
 

--- a/src/types/options/multigraphRequestOptions.ts
+++ b/src/types/options/multigraphRequestOptions.ts
@@ -8,35 +8,62 @@ export enum MultigraphRequestAggregation {
   MEAN = 'mean',
   MEDIAN = 'median',
   NEAREST = 'nearest',
-  UNION = 'routing_union'
+  UNION = 'routing_union',
+  MATH = 'math',
+  GRAVITATION = 'gravitation_huff'
 }
 
 export enum MultigraphRequestLayer {
-  EDGE = 'edge',
-  NODE = 'node',
+  IDENTITY = 'identity',
   TILE = 'tile',
   HEXAGON = 'hexagon',
-  TILE_NODE = 'tile_node',
-  HEXAGON_NODE = 'hexagon_node'
+  CUSTOM_GEOMETRIES = 'custom_geometries'
 }
+
+export interface MultigraphAggregationOptions {
+  type: MultigraphRequestAggregation
+  ignoreOutliers?: boolean
+  outlierPenalty?: number
+  minSourcesRatio?: number
+  minSourcesCount?: number
+  maxResultValue?: number
+  maxResultValueRatio?: number
+  filterValuesForSourceOrigins?: string[]
+  gravitationExponent?: number
+  mathExpression?: string
+  postAggregationFactor?: number
+  aggregationInputParameters?: {
+    [parameterName: string]: {
+      inputFactor?: number
+      gravitationAttractionStrength?: number
+      gravitationPositiveInfluence?: number
+    }
+  }
+}
+
 
 export interface MultigraphSpecificRequestOptions {
 
-  aggregation: {
-    type: MultigraphRequestAggregation
-    ignoreOutliers?: boolean
-    outlierPenalty?: number
-    minSourcesRatio?: number
-    minSourcesCount?: number
-    maxResultValue?: number
-    maxResultValueRatio?: number
-    filterValuesForSourceOrigins?: string[]
+  preAggregationPipeline: {
+    [pipelineName: string]: MultigraphAggregationOptions
   }
+
+  referencedStatisticIds: {
+    [parameterName: string]: number
+  }
+
+  aggregation: MultigraphAggregationOptions
 
   serialization: {
     format: 'geojson' | 'json' | 'mvt'
     decimalPrecision?: number
     maxGeometryCount?: number
+  }
+
+  domain: {
+    type: 'edge' | 'node' | 'statistic_geometry'
+    edgeAggregationType?: 'min' | 'max' | 'mean'
+    statisticGroupId?: number
   }
 
   layer: {
@@ -46,6 +73,7 @@ export interface MultigraphSpecificRequestOptions {
     minGeometryDetailLevel?: number
     maxGeometryDetailLevel?: number
     geometryDetailLevel?: number
+    customGeometryMergeAggregation?: 'max' | 'mean' | 'min' | 'sum'
   }
 
   edgeClasses?: number[]

--- a/src/util/requestUtil.ts
+++ b/src/util/requestUtil.ts
@@ -93,6 +93,8 @@ export class RequestsUtil {
         } else {
           responseValue = JSON.parse(data)
         }
+      } else if (method === 'POST-RAW') {
+        responseValue = await response.text()
       } else {
         responseValue = response.json()
       }


### PR DESCRIPTION
Expand the Multigraph options and the Stateful Multigraph request payload with all parameters supported nowadays.

All requests to the Stateful Multigraph must send a serviceUrl URL parameter just like the Statistics Service on the production version.

When creating a new Multigraph, request its UUID as plain-text and don't try to parse it as JSON. For this, change the pseudo-method "POST-RAW" to not parse the response.

Provide a tiles URL to be used as tile layer source for maps.